### PR TITLE
feat: add ERP invoice/payment and accounting curriculum blog posts

### DIFF
--- a/accounting-erp-curriculum.html
+++ b/accounting-erp-curriculum.html
@@ -1,0 +1,776 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Accounting to ERP: The Complete Learning Roadmap | Md. Mostasim Mahmud Tasim</title>
+<meta name="description" content="A 15-level, 35-phase curriculum blueprint that takes a reader from absolute-beginner bookkeeping to SAP/Odoo-style ERP accounting architecture — the content plan behind this blog's accounting series.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+<link rel="stylesheet" href="css/style.css">
+<style>
+/* Article Specific Styles */
+.article-container { max-width: 860px; margin: 0 auto; padding: 0 24px; }
+.article-content { font-size: 1.0625rem; line-height: 1.8; color: var(--text-secondary); }
+.article-content h2 { font-size: 2rem; margin-top: 3rem; margin-bottom: 1.5rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border); color: var(--text-primary); font-weight: 700; }
+.article-content h3 { font-size: 1.375rem; margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary); font-weight: 700; }
+.article-content h4 { font-size: 1.125rem; margin-top: 2rem; margin-bottom: 1rem; color: var(--text-primary); font-weight: 600; }
+.article-content p { margin-bottom: 1.5rem; }
+.article-content ul, .article-content ol { margin: 1.5rem 0; padding-left: 2rem; }
+.article-content li { margin-bottom: 0.5rem; }
+.article-content pre { background: #1a1a1a; color: #f8f8f2; padding: 1.5rem; border-radius: 8px; overflow-x: auto; margin: 1.5rem 0; font-family: 'Courier New', monospace; font-size: 0.875rem; line-height: 1.5; cursor: pointer; }
+.article-content code { background: var(--bg-alt); color: var(--text-primary); padding: 0.2rem 0.4rem; border-radius: 4px; font-family: 'Courier New', monospace; font-size: 0.875rem; }
+.article-content pre code { background: transparent; color: inherit; padding: 0; }
+.article-content table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.875rem; }
+.article-content th, .article-content td { border: 1px solid var(--border); padding: 9px 12px; text-align: left; vertical-align: top; }
+.article-content th { background: var(--bg-alt); color: var(--text-primary); font-weight: 700; }
+.table-wrap { overflow-x: auto; }
+.info-box { background: var(--accent-subtle); border-left: 4px solid var(--accent); padding: 1.5rem; margin: 2rem 0; border-radius: 0 8px 8px 0; color: var(--text-primary); }
+.warning-box { background: #fff7ed; border-left: 4px solid #f97316; padding: 1.5rem; margin: 2rem 0; border-radius: 0 8px 8px 0; color: var(--text-primary); }
+.success-box { background: #f0fdf4; border-left: 4px solid #22c55e; padding: 1.5rem; margin: 2rem 0; border-radius: 0 8px 8px 0; color: var(--text-primary); }
+.table-of-contents { background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 1.5rem; margin: 2rem 0; border-radius: 0 12px 12px 0; }
+.table-of-contents ul { list-style: none; padding-left: 0; columns: 2; column-gap: 24px; }
+.table-of-contents li { margin-bottom: 0.6rem; padding-left: 1.5rem; position: relative; break-inside: avoid; }
+.table-of-contents li:before { content: "→"; position: absolute; left: 0; color: var(--accent); }
+.table-of-contents a { color: var(--accent); text-decoration: none; font-weight: 500; font-size: 0.9375rem; }
+.table-of-contents a:hover { text-decoration: underline; }
+@media (max-width: 640px) { .table-of-contents ul { columns: 1; } }
+header h1 { font-size: 2.375rem; font-weight: 800; color: var(--text-primary); line-height: 1.2; margin-bottom: 1.5rem; margin-top: 2rem; }
+header .category-badge { display: inline-block; background: var(--accent-subtle); color: var(--accent); padding: 6px 16px; border-radius: 20px; font-size: 0.8125rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+.reading-time { font-size: 0.875rem; color: var(--text-tertiary); font-weight: 500; }
+header p.text-center { text-align: center; margin-bottom: 1rem; color: var(--text-secondary); }
+
+/* Flow diagram */
+.diagram-scroll { overflow-x: auto; margin: 2rem 0; padding-bottom: 4px; }
+.flow-diagram { display: flex; align-items: stretch; gap: 0; min-width: min-content; }
+.flow-step { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; font-size: 0.75rem; font-weight: 700; color: var(--text-primary); text-align: center; min-width: 108px; display: flex; flex-direction: column; justify-content: center; text-decoration: none; }
+.flow-step small { display: block; font-weight: 400; color: var(--text-tertiary); font-size: 0.625rem; margin-top: 6px; line-height: 1.4; }
+.flow-arrow { display: flex; align-items: center; justify-content: center; color: var(--accent); font-size: 1.1rem; flex: 0 0 auto; padding: 0 8px; }
+
+/* Level cards */
+.level-head { display: flex; align-items: center; gap: 12px; margin: 2.5rem 0 0.75rem; flex-wrap: wrap; }
+.level-num { background: var(--accent); color: #fff; font-weight: 800; font-size: 0.8125rem; padding: 5px 14px; border-radius: 20px; white-space: nowrap; }
+.level-head h3 { margin: 0; }
+.level-objective { font-size: 0.9375rem; color: var(--text-secondary); margin-bottom: 1rem; }
+.meta-line { font-size: 0.875rem; margin: 0.5rem 0; }
+.meta-line strong { color: var(--text-primary); }
+.connects-to { font-size: 0.8125rem; color: var(--text-tertiary); border-top: 1px dashed var(--border); padding-top: 10px; margin-top: 1rem; }
+
+/* Six-perspective flow */
+.perspective-flow { display: flex; flex-direction: column; align-items: center; gap: 0; margin: 2rem 0; }
+.perspective-item { background: var(--bg-elevated); border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 8px; padding: 14px 22px; text-align: center; max-width: 460px; width: 100%; }
+.perspective-item .persp-label { font-size: 0.6875rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent); display: block; margin-bottom: 4px; }
+.perspective-item .persp-question { font-size: 0.9375rem; color: var(--text-primary); font-weight: 600; }
+.perspective-arrow { color: var(--accent); font-size: 1.1rem; padding: 4px 0; }
+
+/* Knowledge tree (category cards) */
+.tree-list { margin: 2rem 0; }
+.tree-category { background: var(--bg-elevated); border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 8px; padding: 14px 18px; margin-bottom: 10px; }
+.tree-category .cat-num { display: inline-block; background: var(--accent); color: #fff; font-size: 0.6875rem; font-weight: 800; padding: 2px 9px; border-radius: 10px; margin-right: 8px; }
+.tree-category .cat-title { font-size: 0.9375rem; font-weight: 700; color: var(--text-primary); }
+.tree-children { margin-top: 10px; padding-left: 4px; display: flex; flex-wrap: wrap; gap: 6px; }
+.tree-child { font-size: 0.75rem; background: var(--bg-alt); border: 1px solid var(--border); color: var(--text-secondary); padding: 4px 10px; border-radius: 12px; }
+.tree-category .maps-to { display: block; margin-top: 10px; font-size: 0.6875rem; color: var(--text-tertiary); }
+.tree-category .maps-to a { color: var(--accent); font-weight: 600; text-decoration: none; }
+.tree-category .maps-to a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<!-- Navigation -->
+<nav class="nav" role="navigation">
+<div class="nav-inner">
+  <a href="index.html" class="nav-brand">Mostasim Mahmud Tasim</a>
+  <ul class="nav-links">
+    <li><a href="index.html#about">About</a></li>
+    <li><a href="index.html#experience">Experience</a></li>
+    <li><a href="index.html#capabilities">Engineering</a></li>
+    <li><a href="index.html#projects">Projects</a></li>
+    <li><a href="index.html#infrastructure">Infrastructure</a></li>
+    <li><a href="blog.html">Blog</a></li>
+    <li><a href="index.html#contact">Contact</a></li>
+  </ul>
+  <div class="nav-actions">
+    <a href="https://github.com/tasim313" class="nav-ext" target="_blank"><i class="fa-brands fa-github"></i></a>
+    <a href="https://www.linkedin.com/in/md-mostasim-mahmud-tasim" class="nav-ext" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
+    <button class="theme-toggle" id="themeToggle"><svg id="sunIcon" style="display:none" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg id="moonIcon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg></button>
+    <button class="mobile-toggle" id="mobileToggle"><span></span><span></span><span></span></button>
+  </div>
+</div>
+</nav>
+<div class="mobile-menu" id="mobileMenu">
+  <a href="index.html#about">About</a>
+  <a href="index.html#experience">Experience</a>
+  <a href="index.html#capabilities">Engineering</a>
+  <a href="index.html#projects">Projects</a>
+  <a href="index.html#infrastructure">Infrastructure</a>
+  <a href="blog.html">Blog</a>
+  <a href="index.html#contact">Contact</a>
+</div>
+
+    <!-- Article Header -->
+    <header class="pt-12 pb-8">
+        <div class="article-container">
+            <div class="text-center mb-8">
+                <span class="category-badge">Accounting Curriculum Blueprint</span>
+                <span class="reading-time ml-4">📚 15 Levels · 35 Phases</span>
+            </div>
+
+            <h1>Accounting to ERP: The Complete Learning Roadmap</h1>
+
+            <div class="text-center text-gray-600 mb-8">
+                <p class="text-sm">Published: <span class="font-semibold">Aug 27, 2026</span></p>
+            </div>
+        </div>
+    </header>
+
+    <!-- Main Article Content -->
+    <main class="pb-16">
+        <div class="article-container">
+            <!-- Table of Contents -->
+            <div class="table-of-contents fade-in">
+                <h3 class="font-bold text-lg mb-4 text-gray-800">📋 Table of Contents</h3>
+                <ul class="space-y-2">
+                    <li><a href="#how-to-use">How to Use This Roadmap</a></li>
+                    <li><a href="#six-perspectives">The Six Perspectives Every Article Must Answer</a></li>
+                    <li><a href="#case-study">The Running Case Study: ABC Trading Ltd.</a></li>
+                    <li><a href="#knowledge-tree">The Knowledge Tree: 15 Subject-Matter Categories</a></li>
+                    <li><a href="#roadmap-glance">The 15-Level Roadmap at a Glance</a></li>
+                    <li><a href="#level-1">Level 1 — Absolute Beginner</a></li>
+                    <li><a href="#level-2">Level 2 — Basic Bookkeeping</a></li>
+                    <li><a href="#level-3">Level 3 — Double-Entry Accounting</a></li>
+                    <li><a href="#level-4">Level 4 — Practical Business Accounting</a></li>
+                    <li><a href="#level-5">Level 5 — Accounts Receivable &amp; Payable</a></li>
+                    <li><a href="#level-6">Level 6 — Sales &amp; Purchase Accounting</a></li>
+                    <li><a href="#level-7">Level 7 — Tax &amp; Inventory Accounting</a></li>
+                    <li><a href="#level-8">Level 8 — Financial Statements</a></li>
+                    <li><a href="#level-9">Level 9 — Advanced Accounting</a></li>
+                    <li><a href="#level-10">Level 10 — ERP Accounting</a></li>
+                    <li><a href="#level-11">Level 11 — ERP Architecture</a></li>
+                    <li><a href="#level-12">Level 12 — SAP/Odoo Concepts</a></li>
+                    <li><a href="#level-13">Level 13 — Enterprise Accounting</a></li>
+                    <li><a href="#level-14">Level 14 — Accounting System Architecture</a></li>
+                    <li><a href="#level-15">Level 15 — Advanced ERP Accounting</a></li>
+                    <li><a href="#content-template">The Article Content Template</a></li>
+                    <li><a href="#sap-odoo">SAP vs Odoo: Concept vs Vocabulary</a></li>
+                    <li><a href="#editorial-rules">Editorial Guidelines for This Series</a></li>
+                </ul>
+            </div>
+
+            <!-- Article Content -->
+            <article class="article-content fade-in">
+
+                <section id="how-to-use">
+                    <h2>📖 How to Use This Roadmap</h2>
+                    <p>This page is not an accounting article — it's the <strong>content blueprint</strong> behind one. Every topic below will eventually become its own full article on this blog, written to the same standard as the already-published <a href="erp-invoice-payment-architecture.html">Invoice vs Payment: The Complete ERP Accounting Architecture</a> — which is itself the fully-expanded version of <a href="#level-10">Level 10</a> below.</p>
+                    <p>The curriculum teaches accounting as <strong>two layers of the same thing</strong>: the traditional discipline (debits, credits, ledgers, statements) and the modern ERP system that automates it (documents, journal engines, subledgers, reconciliation). Every topic, at every level, is meant to be traceable through one chain:</p>
+                    <div class="diagram-scroll">
+                        <div class="flow-diagram">
+                            <div class="flow-step">Business Event</div><div class="flow-arrow">→</div>
+                            <div class="flow-step">Business Document</div><div class="flow-arrow">→</div>
+                            <div class="flow-step">Accounting Event</div><div class="flow-arrow">→</div>
+                            <div class="flow-step">Journal Entry</div><div class="flow-arrow">→</div>
+                            <div class="flow-step">Subledger</div><div class="flow-arrow">→</div>
+                            <div class="flow-step">General Ledger</div><div class="flow-arrow">→</div>
+                            <div class="flow-step">Trial Balance</div><div class="flow-arrow">→</div>
+                            <div class="flow-step">Financial Statements</div>
+                        </div>
+                    </div>
+                    <div class="info-box">
+                        <strong>💡 The rule every level follows:</strong> never introduce an ERP or architecture concept until the plain accounting concept underneath it has been taught first, and never teach a plain accounting concept without eventually showing where it lives in an ERP. Levels 1–9 build the accounting foundation; Levels 10–15 rebuild the same knowledge as a system.
+                    </div>
+                </section>
+
+                <section id="six-perspectives">
+                    <h2>🔭 The Six Perspectives Every Article Must Answer</h2>
+                    <p>Because the ultimate goal of this series is to understand accounting well enough to <em>design</em> an ERP accounting module — not just use one — every single article, at every level, must answer the same transaction from six different vantage points. Skipping any one of them is what turns a topic into "just theory" or "just a how-to click guide" instead of a complete picture.</p>
+
+                    <div class="perspective-flow">
+                        <div class="perspective-item"><span class="persp-label">Accountant Perspective</span><span class="persp-question">What happened financially?</span></div>
+                        <div class="perspective-arrow">↓</div>
+                        <div class="perspective-item"><span class="persp-label">ERP User Perspective</span><span class="persp-question">What document did I create?</span></div>
+                        <div class="perspective-arrow">↓</div>
+                        <div class="perspective-item"><span class="persp-label">ERP Functional Perspective</span><span class="persp-question">What business rule was triggered?</span></div>
+                        <div class="perspective-arrow">↓</div>
+                        <div class="perspective-item"><span class="persp-label">Accounting Perspective</span><span class="persp-question">What debit/credit was generated?</span></div>
+                        <div class="perspective-arrow">↓</div>
+                        <div class="perspective-item"><span class="persp-label">System Architecture Perspective</span><span class="persp-question">What records/relationships were created?</span></div>
+                        <div class="perspective-arrow">↓</div>
+                        <div class="perspective-item"><span class="persp-label">Audit Perspective</span><span class="persp-question">Can we prove what happened?</span></div>
+                    </div>
+
+                    <p>Grounded in one concrete transaction — ABC Trading Ltd. posts a ৳55,000 credit sale — the six perspectives look like this:</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Perspective</th><th>Answers</th><th>Template field it fills</th><th>For this transaction</th></tr></thead>
+                        <tbody>
+                            <tr><td>Accountant</td><td>What happened financially?</td><td>Business Scenario</td><td>Sold goods worth ৳55,000 to a customer on credit</td></tr>
+                            <tr><td>ERP User</td><td>What document did I create?</td><td>Documents Involved</td><td>A Sales Invoice, e.g. <code>INV-2026-000123</code>, posted in the system</td></tr>
+                            <tr><td>ERP Functional</td><td>What business rule was triggered?</td><td>Accounting Flow / ERP Workflow</td><td>The "Invoice → AR" posting rule fires automatically on confirm</td></tr>
+                            <tr><td>Accounting</td><td>What debit/credit was generated?</td><td>Debit/Credit Concepts</td><td><code>DR Accounts Receivable 55,000 / CR Sales Revenue 50,000 / CR VAT Payable 5,000</code></td></tr>
+                            <tr><td>System Architecture</td><td>What records/relationships were created?</td><td>Database Relationship</td><td>1 <code>Invoice</code> row, N <code>InvoiceLine</code> rows, 1 <code>JournalEntry</code> + its <code>JournalEntryLine</code> rows, all FK'd to the Customer</td></tr>
+                            <tr><td>Audit</td><td>Can we prove what happened?</td><td>Real-World ERP Scenario</td><td>An <code>AuditLog</code> row: who posted it, when, the reference document, old/new values</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <div class="info-box">
+                        <strong>💡 Why all six, every time:</strong> a reader who only gets the Accountant and Accounting perspectives learns bookkeeping but not ERP design. A reader who only gets the ERP User and Functional perspectives learns to click buttons but not why the numbers are trustworthy. All six together is what separates "accounting knowledge" from "the knowledge needed to design an ERP accounting module" — the explicit long-term goal of this series.
+                    </div>
+                </section>
+
+                <section id="case-study">
+                    <h2>🏢 The Running Case Study: ABC Trading Ltd.</h2>
+                    <p>One fictional company is reused across every level so a reader can watch a single, coherent set of books grow in complexity from page one to the capstone. It opens with a balanced accounting equation on day one:</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Account</th><th>Opening balance</th><th>Type</th></tr></thead>
+                        <tbody>
+                            <tr><td>Cash</td><td>৳100,000</td><td>Asset</td></tr>
+                            <tr><td>Bank</td><td>৳500,000</td><td>Asset</td></tr>
+                            <tr><td>Inventory</td><td>৳300,000</td><td>Asset</td></tr>
+                            <tr><td><strong>Total Assets</strong></td><td><strong>৳900,000</strong></td><td></td></tr>
+                            <tr><td>Capital</td><td>৳900,000</td><td>Equity</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p>From here, each level introduces the next layer the company needs — its first customer and supplier at Level 5–6, its first VAT return at Level 7, its first depreciating asset at Level 9, its first branch and foreign-currency invoice at Level 13 — so that by <a href="#level-15">Level 15</a> the reader has effectively watched one company's books mature from a single trial balance into a full multi-branch, multi-currency, audited ERP ledger.</p>
+                </section>
+
+                <section id="knowledge-tree">
+                    <h2>🌳 The Knowledge Tree: 15 Subject-Matter Categories</h2>
+                    <p>The 15 Levels below organize the series by <strong>difficulty</strong> — what a reader needs to already know. This tree organizes the same content by <strong>subject</strong> — what a reader is trying to look up. They're two lenses on one knowledge base, not two competing structures: every branch below links to the level(s) that actually teach it, so the blog reads as a connected tree rather than a hundred unrelated posts.</p>
+
+                    <div class="tree-list">
+                        <div class="tree-category">
+                            <span class="cat-num">01</span><span class="cat-title">Fundamentals</span>
+                            <div class="tree-children"><span class="tree-child">What is Accounting?</span><span class="tree-child">Assets</span><span class="tree-child">Liabilities</span><span class="tree-child">Equity</span><span class="tree-child">Revenue</span><span class="tree-child">Expenses</span></div>
+                            <span class="maps-to">Maps to <a href="#level-1">Level 1 — Absolute Beginner</a></span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">02</span><span class="cat-title">Double Entry</span>
+                            <div class="tree-children"><span class="tree-child">Debit</span><span class="tree-child">Credit</span><span class="tree-child">Journal</span><span class="tree-child">Ledger</span><span class="tree-child">Trial Balance</span></div>
+                            <span class="maps-to">Maps to <a href="#level-3">Level 3 — Double-Entry Accounting</a></span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">03</span><span class="cat-title">Chart of Accounts</span>
+                            <div class="tree-children"><span class="tree-child">Account numbering</span><span class="tree-child">Account groups</span><span class="tree-child">Control accounts</span></div>
+                            <span class="maps-to">Maps to <a href="#level-2">Level 2 — Basic Bookkeeping</a> (Phase 3)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">04</span><span class="cat-title">General Ledger</span>
+                            <div class="tree-children"><span class="tree-child">Posting</span><span class="tree-child">Account balance</span><span class="tree-child">GL reconciliation</span></div>
+                            <span class="maps-to">Maps to <a href="#level-2">Level 2 — Basic Bookkeeping</a> (Phase 4)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">05</span><span class="cat-title">Sales Accounting</span>
+                            <div class="tree-children"><span class="tree-child">Sales Order</span><span class="tree-child">Delivery</span><span class="tree-child">Invoice</span><span class="tree-child">AR</span><span class="tree-child">Payment</span></div>
+                            <span class="maps-to">Maps to <a href="#level-6">Level 6 — Sales &amp; Purchase Accounting</a> (Phase 5)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">06</span><span class="cat-title">Purchase Accounting</span>
+                            <div class="tree-children"><span class="tree-child">Purchase Order</span><span class="tree-child">Receipt</span><span class="tree-child">Supplier Bill</span><span class="tree-child">AP</span><span class="tree-child">Payment</span></div>
+                            <span class="maps-to">Maps to <a href="#level-6">Level 6 — Sales &amp; Purchase Accounting</a> (Phase 6)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">07</span><span class="cat-title">Invoice &amp; Payment</span>
+                            <div class="tree-children"><span class="tree-child">Full Payment</span><span class="tree-child">Partial Payment</span><span class="tree-child">Multiple Payments</span><span class="tree-child">Overpayment</span><span class="tree-child">Advance</span><span class="tree-child">Unallocated</span><span class="tree-child">Refund</span><span class="tree-child">Reversal</span></div>
+                            <span class="maps-to">Maps to <a href="#level-5">Level 5 — AR &amp; AP</a> and <a href="#level-10">Level 10 — ERP Accounting</a> · fully published: <a href="erp-invoice-payment-architecture.html">Invoice vs Payment</a></span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">08</span><span class="cat-title">Reconciliation</span>
+                            <div class="tree-children"><span class="tree-child">AR</span><span class="tree-child">AP</span><span class="tree-child">Bank</span><span class="tree-child">GL</span></div>
+                            <span class="maps-to">Maps to <a href="#level-4">Level 4 — Practical Business Accounting</a> (bank) and <a href="#level-14">Level 14 — System Architecture</a> (Phase 30, full reconciliation)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">09</span><span class="cat-title">Inventory Accounting</span>
+                            <div class="tree-children"><span class="tree-child">Valuation</span><span class="tree-child">COGS</span><span class="tree-child">Stock adjustment</span></div>
+                            <span class="maps-to">Maps to <a href="#level-7">Level 7 — Tax &amp; Inventory Accounting</a> (Phase 16)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">10</span><span class="cat-title">Tax Accounting</span>
+                            <div class="tree-children"><span class="tree-child">Input tax</span><span class="tree-child">Output tax</span><span class="tree-child">Tax reporting</span></div>
+                            <span class="maps-to">Maps to <a href="#level-7">Level 7 — Tax &amp; Inventory Accounting</a> (Phase 15)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">11</span><span class="cat-title">Fixed Assets</span>
+                            <div class="tree-children"><span class="tree-child">Capitalization</span><span class="tree-child">Depreciation</span><span class="tree-child">Disposal</span></div>
+                            <span class="maps-to">Maps to <a href="#level-9">Level 9 — Advanced Accounting</a> (Phase 17)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">12</span><span class="cat-title">Accrual &amp; Deferral</span>
+                            <div class="tree-children"><span class="tree-child">Accrued expense/revenue</span><span class="tree-child">Prepaid expense</span><span class="tree-child">Deferred revenue</span></div>
+                            <span class="maps-to">Maps to <a href="#level-8">Level 8 — Financial Statements</a> (Phase 18)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">13</span><span class="cat-title">Financial Statements</span>
+                            <div class="tree-children"><span class="tree-child">Balance Sheet</span><span class="tree-child">Income Statement</span><span class="tree-child">Cash Flow</span></div>
+                            <span class="maps-to">Maps to <a href="#level-8">Level 8 — Financial Statements</a> (Phase 20)</span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">14</span><span class="cat-title">Advanced Accounting</span>
+                            <div class="tree-children"><span class="tree-child">Cost accounting</span><span class="tree-child">Management accounting</span><span class="tree-child">Multi-branch</span><span class="tree-child">Multi-company</span><span class="tree-child">Multi-currency</span></div>
+                            <span class="maps-to">Maps to <a href="#level-9">Level 9 — Advanced Accounting</a> and <a href="#level-13">Level 13 — Enterprise Accounting</a></span>
+                        </div>
+                        <div class="tree-category">
+                            <span class="cat-num">15</span><span class="cat-title">ERP Accounting</span>
+                            <div class="tree-children"><span class="tree-child">ERP Document Lifecycle</span><span class="tree-child">Accounting Engine</span><span class="tree-child">Subledger</span><span class="tree-child">GL</span><span class="tree-child">Audit Trail</span><span class="tree-child">SAP Concepts</span><span class="tree-child">Odoo Concepts</span><span class="tree-child">Accounting System Architecture</span></div>
+                            <span class="maps-to">Maps to <a href="#level-10">Level 10</a>, <a href="#level-11">Level 11</a>, <a href="#level-12">Level 12</a>, and <a href="#level-14">Level 14</a></span>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="roadmap-glance">
+                    <h2>🗺️ The 15-Level Roadmap at a Glance</h2>
+                    <p>Click any level to jump to its phase breakdown.</p>
+                    <div class="diagram-scroll">
+                        <div class="flow-diagram">
+                            <a href="#level-1" class="flow-step">L1<small>Absolute Beginner</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-2" class="flow-step">L2<small>Basic Bookkeeping</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-3" class="flow-step">L3<small>Double-Entry</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-4" class="flow-step">L4<small>Practical Accounting</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-5" class="flow-step">L5<small>AR / AP</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-6" class="flow-step">L6<small>Sales / Purchase</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-7" class="flow-step">L7<small>Tax / Inventory</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-8" class="flow-step">L8<small>Financial Statements</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-9" class="flow-step">L9<small>Advanced Accounting</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-10" class="flow-step">L10<small>ERP Accounting</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-11" class="flow-step">L11<small>ERP Architecture</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-12" class="flow-step">L12<small>SAP / Odoo Concepts</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-13" class="flow-step">L13<small>Enterprise Accounting</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-14" class="flow-step">L14<small>System Architecture</small></a><div class="flow-arrow">→</div>
+                            <a href="#level-15" class="flow-step">L15<small>Advanced ERP (Capstone)</small></a>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- LEVEL 1 -->
+                <section id="level-1">
+                    <div class="level-head"><span class="level-num">LEVEL 1</span><h3>Absolute Beginner</h3></div>
+                    <p class="level-objective">Understand what accounting is and internalize the five account types and the accounting equation before a single journal entry is introduced.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 1</strong><br>Accounting Fundamentals</td><td>None — curriculum entry point</td><td>What is Accounting; Accounting vs Bookkeeping; Assets, Liabilities, Equity, Revenue, Expenses, Profit, Loss; Accounting Equation; Debit, Credit, Account; Chart of Accounts; Account Types; Normal Balance; Journal, Ledger, General Ledger, Trial Balance; Financial Statements; Fiscal Year, Accounting Period; Opening/Closing Balance</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd.'s day-one balance sheet — Cash 100,000 + Bank 500,000 + Inventory 300,000 = Capital 900,000 — read purely as <code>Assets = Equity</code>, the accounting equation in its simplest form, before any transaction happens.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a balance-scale visual for <code>Assets = Liabilities + Equity</code>, plus a five-box "account type" reference card with each type's normal balance side marked.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> treating "debit" and "credit" as synonyms for "increase" and "decrease" before the account-type-dependent rule is taught in Level 3 — this is the single most common misconception to defuse early.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> nothing precedes it. Feeds directly into Level 2 once the five account types are internalized.</p>
+                </section>
+
+                <!-- LEVEL 2 -->
+                <section id="level-2">
+                    <div class="level-head"><span class="level-num">LEVEL 2</span><h3>Basic Bookkeeping</h3></div>
+                    <p class="level-objective">Learn to structure a Chart of Accounts and post transactions into a ledger before tackling formal double-entry theory.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 3</strong><br>Chart of Accounts</td><td>Level 1</td><td>What/why COA; account numbering &amp; hierarchy; account groups; control accounts; cash/bank accounts; AR/AP control accounts; revenue, COGS, expense, tax, fixed asset, accumulated depreciation, liability, equity, suspense, clearing accounts; retained earnings</td></tr>
+                            <tr><td><strong>Phase 4</strong><br>General Ledger</td><td>Phase 3</td><td>What is GL; GL vs subledger; posting; journal &amp; journal line; account balance; debit/credit balance; period, opening, closing balance; GL reporting; control accounts; GL reconciliation; trial balance</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd.'s numbered COA — 1000 Cash, 1100 Bank, 1200 Accounts Receivable, 1300 Inventory, 2000 Accounts Payable, 3000 Capital, 4000 Sales Revenue, 5000 COGS — with the Level 1 opening balances posted as the very first GL entry.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a Chart-of-Accounts tree (Assets/Liabilities/Equity/Revenue/Expenses as root nodes), and a <code>Subledger → Control Account → General Ledger</code> flow diagram.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> numbering accounts ad hoc instead of in ranges (1000s = Assets, 2000s = Liabilities…), which makes control-account mapping and reporting brittle the moment the COA grows.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 1 before it; Level 3 supplies the posting mechanics for everything recorded here.</p>
+                </section>
+
+                <!-- LEVEL 3 -->
+                <section id="level-3">
+                    <div class="level-head"><span class="level-num">LEVEL 3</span><h3>Double-Entry Accounting</h3></div>
+                    <p class="level-objective">Master the debit/credit rule for every account type and post a full sequence of transactions to a balanced trial balance.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 2</strong><br>Double-Entry Accounting</td><td>Level 1, Level 2</td><td>Meaning of double-entry; why every transaction has two sides; traditional debit/credit rules; modern accounting-equation approach; asset/liability/equity/revenue/expense account behavior; journal entries; posting to ledger; trial balance; detecting errors; balanced journal entries</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario — ABC Trading Ltd.'s first month, ten transactions:</strong></p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Event</th><th>Debit</th><th>Credit</th></tr></thead>
+                        <tbody>
+                            <tr><td>Owner invests 100,000</td><td>Cash 100,000</td><td>Capital 100,000</td></tr>
+                            <tr><td>Buy inventory for cash 20,000</td><td>Inventory 20,000</td><td>Cash 20,000</td></tr>
+                            <tr><td>Buy inventory on credit 30,000</td><td>Inventory 30,000</td><td>Accounts Payable 30,000</td></tr>
+                            <tr><td>Sell goods for cash 15,000</td><td>Cash 15,000</td><td>Sales Revenue 15,000</td></tr>
+                            <tr><td>Sell goods on credit 25,000</td><td>Accounts Receivable 25,000</td><td>Sales Revenue 25,000</td></tr>
+                            <tr><td>Pay supplier 10,000</td><td>Accounts Payable 10,000</td><td>Cash 10,000</td></tr>
+                            <tr><td>Receive customer payment 12,000</td><td>Cash 12,000</td><td>Accounts Receivable 12,000</td></tr>
+                            <tr><td>Pay salary 20,000</td><td>Salary Expense 20,000</td><td>Cash 20,000</td></tr>
+                            <tr><td>Pay rent 10,000</td><td>Rent Expense 10,000</td><td>Cash 10,000</td></tr>
+                            <tr><td>Receive bank loan 500,000</td><td>Bank 500,000</td><td>Loan Payable 500,000</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a T-account for each account type touched above, and a debit/credit decision table (increase/decrease by account type) — the same pattern already used in the <a href="erp-invoice-payment-architecture.html#double-entry">published double-entry section</a>.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> posting an entry where debits ≠ credits and not catching it until the trial balance quietly fails to balance weeks later.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 2 (accounts to post into) before it; Level 5 and Level 6 after it are simply double-entry applied to specific business processes.</p>
+                </section>
+
+                <!-- LEVEL 4 -->
+                <section id="level-4">
+                    <div class="level-head"><span class="level-num">LEVEL 4</span><h3>Practical Business Accounting</h3></div>
+                    <p class="level-objective">Apply double-entry to real cash and bank movements — the first genuinely operational accounting a business performs daily.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 13</strong><br>Bank &amp; Cash Accounting</td><td>Level 3</td><td>Cash receipt/payment; bank receipt/payment; bank/cash transfer; bank charges; payment gateway &amp; clearing; cash shortage/overage; unidentified bank transaction; duplicate payment; payment reversal</td></tr>
+                            <tr><td><strong>Phase 14</strong><br>Bank Reconciliation</td><td>Phase 13</td><td>What/why reconciliation; bank statement vs ERP bank ledger; matched/unmatched transaction; outstanding cheque; bank charge; interest income; unknown deposit; duplicate transaction; timing difference; reconciliation adjustment &amp; status</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd.'s bank statement shows a ৳500 bank charge and a ৳2,000 deposit not yet in the ERP — walk through matching, then posting both adjustments until the bank ledger and statement agree.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a reconciliation diagram — two parallel ledgers (bank statement vs ERP bank account) converging into a matched/unmatched split, then an adjustment loop.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> "fixing" a reconciliation by editing the original bank transaction instead of posting a separate reconciling adjustment entry that preserves both records.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 3 before it; Level 5 after it reuses this exact reconciliation logic for customers and suppliers.</p>
+                </section>
+
+                <!-- LEVEL 5 -->
+                <section id="level-5">
+                    <div class="level-head"><span class="level-num">LEVEL 5</span><h3>Accounts Receivable &amp; Accounts Payable</h3></div>
+                    <p class="level-objective">Track what customers owe and what the business owes suppliers as running subledger balances, never as a single mutable field on the invoice.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 7</strong><br>Accounts Receivable</td><td>Level 4</td><td>What is AR; customer balance; invoice; due date; payment terms; outstanding amount; partial/full/overpayment; advance payment; unallocated payment; payment allocation; credit note; refund; write-off; bad debt; AR aging; customer statement; collection process; reconciliation</td></tr>
+                            <tr><td><strong>Phase 8</strong><br>Accounts Payable</td><td>Phase 7 (mirror)</td><td>Outstanding AP; partial/full settlement; overpayment; supplier advance; credit balance; refund; payment reversal; write-off — every AR concept mirrored to the supplier side</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> a ৳1,000 customer invoice run through Payment = 0 / 1 / 100 / 250 / 500 / 700 / 900 / 999 / 1,000 / 1,100 / 1,500, each mapped to UNPAID → PARTIALLY_PAID → PAID → PAID + credit — then the identical table re-run for a ৳1,000 supplier bill.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a running-balance customer/supplier statement, and an AR/AP aging bucket chart (Current / 30 / 60 / 90+ days).</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> storing a single <code>paid_amount</code> field on the invoice instead of a subledger of allocations — it breaks the moment one payment must settle two invoices.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 4 before it; Level 6 after it is where AR and AP balances actually get created. Fully expanded in <a href="erp-invoice-payment-architecture.html">Invoice vs Payment: The Complete ERP Accounting Architecture</a>.</p>
+                </section>
+
+                <!-- LEVEL 6 -->
+                <section id="level-6">
+                    <div class="level-head"><span class="level-num">LEVEL 6</span><h3>Sales &amp; Purchase Accounting</h3></div>
+                    <p class="level-objective">Walk the full document chain that creates the AR and AP balances Level 5 assumed already existed.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 5</strong><br>Sales Accounting</td><td>Level 5</td><td>Customer; quotation; sales order; delivery; sales invoice; credit note; debit note; customer payment; payment allocation; customer statement; AR aging; bad debt; write-off; refund</td></tr>
+                            <tr><td><strong>Phase 6</strong><br>Purchase Accounting</td><td>Phase 5 (mirror)</td><td>Supplier master; purchase order; goods receipt; supplier invoice; accounts payable; supplier payment; supplier advance; supplier credit; debit note; purchase return; payment allocation; supplier reconciliation; AP aging</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd. quotes a customer ৳50,000, converts it to a sales order, delivers (inventory −20 units, COGS ৳35,000), and invoices ৳55,000 including VAT — mirrored by buying that same inventory from a supplier for ৳100,000 + VAT.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> the Quotation → Sales Order → Delivery → Invoice flow (reuse the diagram already built for the published <a href="erp-invoice-payment-architecture.html#sales-flow">Sales Flow section</a>) and its Purchase-side mirror.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> treating the Sales Order as if it already creates a receivable — it doesn't; only the posted Invoice does.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 5 before it; Level 7 after it covers the Tax and Inventory accounts every line of these documents ultimately touches.</p>
+                </section>
+
+                <!-- LEVEL 7 -->
+                <section id="level-7">
+                    <div class="level-head"><span class="level-num">LEVEL 7</span><h3>Tax &amp; Inventory Accounting</h3></div>
+                    <p class="level-objective">Go deeper into the two accounts every sales/purchase line touches — tax and inventory — beyond what Level 6 needed for the basic flow. (Bank mechanics were already covered at Level 4.)</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 15</strong><br>Tax Accounting</td><td>Level 6</td><td>Sales tax, VAT; purchase VAT; input/output tax; tax payable/receivable; tax-inclusive/exclusive pricing; tax invoice; tax credit note; tax adjustment; tax reporting</td></tr>
+                            <tr><td><strong>Phase 16</strong><br>Inventory Accounting</td><td>Level 6</td><td>Inventory asset; goods receipt; valuation (FIFO, weighted average, standard cost); COGS; stock issue; purchase/sales return; inventory adjustment/write-off; perpetual vs periodic inventory</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd. sells goods for ৳1,000 + 15% VAT = ৳1,150; under perpetual inventory the same sale also posts <code>DR COGS / CR Inventory</code> at the ৳600 cost of the units sold — two journal entries generated from one invoice.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a "one invoice, two journal entries" side-by-side diagram (revenue-recognition entry + COGS/inventory entry), and a FIFO-vs-weighted-average worked comparison table.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> posting VAT into the Sales Revenue account instead of a separate VAT Payable liability, overstating both revenue and tax exposure.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 6 before it; Level 8 after it, once every account has a full period's activity to close.</p>
+                </section>
+
+                <!-- LEVEL 8 -->
+                <section id="level-8">
+                    <div class="level-head"><span class="level-num">LEVEL 8</span><h3>Financial Statements</h3></div>
+                    <p class="level-objective">Turn a fully populated trial balance into accruals-adjusted, closed-period financial statements.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 18</strong><br>Accruals &amp; Deferrals</td><td>Level 7</td><td>Accrued expense/revenue; prepaid expense; deferred revenue; month-end adjustment; reversing entry; recurring journal</td></tr>
+                            <tr><td><strong>Phase 19</strong><br>Period-End &amp; Closing</td><td>Phase 18</td><td>Full month-end workflow (AR → AP → bank → inventory reconciliation → depreciation → accruals → prepayments → tax → adjustments → trial balance → financial statements → closing); open/closed/locked periods; backdated transactions; reopening</td></tr>
+                            <tr><td><strong>Phase 20</strong><br>Financial Statements</td><td>Phase 19</td><td>Balance Sheet; Income Statement; Cash Flow Statement; Statement of Changes in Equity; Trial Balance; General Ledger; AR/AP aging — and exactly how journal entries flow into each</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd. accrues an unpaid ৳5,000 electricity bill at month-end (<code>DR Utilities Expense / CR Accrued Liabilities</code>) so the Income Statement reflects the cost in the month it was incurred, not the month it's paid.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> the month-end closing workflow as a linear flowchart (same visual language as the <a href="erp-invoice-payment-architecture.html#decision-flowchart">settlement decision flowchart</a>), and a journal-entry-to-financial-statement-line tracing diagram.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> closing a period before bank and AR/AP reconciliations are complete, then having to reopen it — reopening should require explicit authorization, never a casual undo.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 7 before it; Level 9 after it operates only on top of a correctly closed period.</p>
+                </section>
+
+                <!-- LEVEL 9 -->
+                <section id="level-9">
+                    <div class="level-head"><span class="level-num">LEVEL 9</span><h3>Advanced Accounting</h3></div>
+                    <p class="level-objective">Extend the closed-period foundation into fixed assets, cost accounting, and management accounting.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 17</strong><br>Fixed Asset Accounting</td><td>Level 8</td><td>Asset purchase; capitalization; asset register; depreciation; accumulated depreciation; useful life; residual value; disposal; sale; impairment; transfer; revaluation</td></tr>
+                            <tr><td><strong>Phase 21</strong><br>Cost Accounting</td><td>Level 8</td><td>Cost center; profit center; department; project; cost allocation; direct/indirect cost; fixed/variable cost; COGS; manufacturing cost; overhead; budget vs actual; variance analysis</td></tr>
+                            <tr><td><strong>Phase 22</strong><br>Management Accounting</td><td>Phase 21</td><td>Budgeting; forecasting; cost analysis; profitability; margin; contribution margin; break-even; department/product/customer/branch profitability</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd. capitalizes a ৳240,000 delivery van with a 5-year useful life and ৳0 residual value; straight-line depreciation posts <code>DR Depreciation Expense 4,000 / CR Accumulated Depreciation 4,000</code> every month.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> an asset lifecycle flowchart — Purchase → Capitalize → Depreciate Monthly → Dispose/Sell — in the same style as the invoice lifecycle diagram.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> expensing a capital purchase directly instead of capitalizing and depreciating it, distorting both the Balance Sheet and one month's Income Statement.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 8 before it; Level 10 after it turns all of this from manual monthly journals into ERP-automated rules.</p>
+                </section>
+
+                <!-- LEVEL 10 -->
+                <section id="level-10">
+                    <div class="level-head"><span class="level-num">LEVEL 10</span><h3>ERP Accounting</h3></div>
+                    <p class="level-objective">Rebuild everything learned so far as the engine an ERP runs automatically — this level is where "accounting user" knowledge becomes "accounting system" knowledge.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 9</strong><br>Invoice &amp; Payment Relationship</td><td>Level 9</td><td>Payment received vs payment allocated; 1↔1, 1↔many, many↔1 allocation; payment without invoice; overpayment; advance; unallocated payment; wrong allocation; reversal; refund; credit note; write-off</td></tr>
+                            <tr><td><strong>Phase 10</strong><br>Document Lifecycle</td><td>Phase 9</td><td>DRAFT → SUBMITTED → APPROVED → POSTED → PARTIALLY SETTLED → SETTLED → REVERSED → CANCELLED for every document type; document status vs accounting status</td></tr>
+                            <tr><td><strong>Phase 11</strong><br>Accounting Journal Engine</td><td>Phase 10</td><td><code>Business Event → Accounting Rule → Journal Entry → Journal Lines → Debit/Credit → Posting → GL</code>, applied to every transaction type covered so far</td></tr>
+                            <tr><td><strong>Phase 12</strong><br>Subledger Accounting</td><td>Phase 11</td><td>AR/AP/Inventory/Fixed Asset/Bank/Cash subledgers; subledger balance vs GL control account; reconciliation between the two</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <div class="success-box">
+                        <strong>✅ Already fully published:</strong> this entire level is expanded in <a href="erp-invoice-payment-architecture.html">Invoice vs Payment: The Complete ERP Accounting Architecture</a> — its relationship map, invoice/payment lifecycle state machine, activity swimlane, settlement flowchart, and the ৳1,000-invoice scenario playbook are the reference implementation every later level's diagrams should match in style.
+                    </div>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> modeling <code>invoice.payment_id</code> as a single foreign key instead of a many-to-many allocation table.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 9 before it; Level 11 after it zooms out from one module to the whole ERP system.</p>
+                </section>
+
+                <!-- LEVEL 11 -->
+                <section id="level-11">
+                    <div class="level-head"><span class="level-num">LEVEL 11</span><h3>ERP Architecture</h3></div>
+                    <p class="level-objective">Zoom out from the invoice/payment module to how every ERP entity interacts across the whole system.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 26</strong><br>ERP Accounting Architecture</td><td>Level 10</td><td>How Customer, Supplier, Product, Warehouse, Sales/Purchase Order, Delivery, Goods Receipt, Invoice, Payment, Payment Allocation, Journal Entry, Journal Line, Account, Chart of Accounts, Fiscal Period, Tax, Currency, Bank, Cash, Cost Center, and Company interact</td></tr>
+                            <tr><td><strong>Phase 27</strong><br>ERP Database Concept</td><td>Phase 26</td><td>Conceptual entities and cardinalities (1:1, 1:N, N:M): <code>Customer → Invoice → Invoice Lines ↔ Payment Allocation ↔ Payment → Journal Entry → Journal Lines → GL Account</code>, and the Supplier-side mirror</td></tr>
+                            <tr><td><strong>Phase 28</strong><br>Accounting Event vs Business Document</td><td>Phase 27</td><td>Sales Order ≠ accounting entry; Delivery ≠ necessarily revenue recognition; Invoice = financial event; Payment = settlement event; Payment Allocation = settlement relationship; why ERP architecture deliberately separates these</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> trace one ABC Trading Ltd. sales order through every entity it touches end to end, marking exactly where — and only where — a journal entry gets generated.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a full entity-relationship diagram covering all ~19 entities from Phase 26, extending the smaller relationship map already built at Level 10.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> giving the <code>invoice</code> table responsibility for AR balance, payment status, and GL posting all at once instead of letting each concern live in its own entity.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 10 before it; Level 12 after it grounds this architecture in real ERP products.</p>
+                </section>
+
+                <!-- LEVEL 12 -->
+                <section id="level-12">
+                    <div class="level-head"><span class="level-num">LEVEL 12</span><h3>SAP/Odoo Concepts</h3></div>
+                    <p class="level-objective">Map every universal concept taught so far onto the vocabulary of two real ERP products, without assuming they implement anything identically.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 33</strong><br>SAP/Odoo Conceptual Mapping</td><td>Level 11</td><td>Customer/Vendor; Chart of Accounts; Journal &amp; Journal Entry; AR/AP; Invoice/Payment; Reconciliation; Fiscal Position; Tax; Bank/Cash Journal; Accounting Period; Cost Center; Analytic Accounting; Asset Accounting — universal concept vs SAP-style term vs Odoo-style term</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> "Payment Allocation" (universal) is conceptually similar to SAP's clearing of open items against a payment document, and to Odoo's reconciling a payment move against an invoice move — same underlying concept, different product vocabulary.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a three-column comparison table (Universal Concept | SAP-style term | Odoo-style term) — see the <a href="#sap-odoo">reference table</a> later on this page.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> presenting SAP or Odoo terminology as if it were the universal accounting concept itself, which confuses readers when they later work with a third ERP.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 11 before it; Level 13 after it needs this shared vocabulary to discuss concrete multi-company/multi-currency setups.</p>
+                </section>
+
+                <!-- LEVEL 13 -->
+                <section id="level-13">
+                    <div class="level-head"><span class="level-num">LEVEL 13</span><h3>Enterprise Accounting</h3></div>
+                    <p class="level-objective">Scale a single-company, single-currency ledger up to multi-branch, multi-company, and multi-currency operations.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 23</strong><br>Multi-Branch Accounting</td><td>Level 12</td><td>Company, branch, warehouse, department, cost center; branch revenue/expense/inventory/cash/bank; inter-branch transfer and accounting</td></tr>
+                            <tr><td><strong>Phase 24</strong><br>Multi-Company Accounting</td><td>Phase 23</td><td>Parent company; subsidiary; intercompany transaction/invoice/payment/receivable/payable; elimination; consolidation</td></tr>
+                            <tr><td><strong>Phase 25</strong><br>Multi-Currency Accounting</td><td>Phase 24</td><td>Transaction vs base/company currency; exchange rate; foreign currency invoice/payment; realized/unrealized gain-loss; currency revaluation</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> ABC Trading Ltd. opens a Chittagong branch and later a Singapore subsidiary; an inter-branch stock transfer and a USD invoice to the Singapore entity both need accounting treatment beyond a single-company, single-currency ledger.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a multi-entity structure diagram (Parent → Subsidiary → Branch → Cost Center) with intercompany transaction arrows and an elimination step at consolidation.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> recording an intercompany invoice as if the counterparty were an ordinary external customer, so it never gets eliminated at consolidation and inflates group revenue.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 12 before it; Level 14 after it, where audit and reconciliation controls have to scale across every one of these entities.</p>
+                </section>
+
+                <!-- LEVEL 14 -->
+                <section id="level-14">
+                    <div class="level-head"><span class="level-num">LEVEL 14</span><h3>Accounting System Architecture</h3></div>
+                    <p class="level-objective">Formalize the audit trail, reconciliation discipline, and error-correction rules that keep a multi-entity ERP's books trustworthy.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 29</strong><br>Audit Trail</td><td>Level 13</td><td>Who created/approved/posted/modified/cancelled/reversed a record; timestamp; old/new value; reason; reference document; approval history; why posted records are reversed, never deleted</td></tr>
+                            <tr><td><strong>Phase 30</strong><br>Reconciliation</td><td>Phase 29</td><td>AR, AP, bank, cash, inventory, subledger-vs-GL, tax, and intercompany reconciliation, each with source A, source B, expected vs actual, difference, investigation, adjustment, approval, resolution</td></tr>
+                            <tr><td><strong>Phase 31</strong><br>Error &amp; Correction Accounting</td><td>Phase 30</td><td>Wrong amount/account/customer/supplier/invoice/allocation; duplicate invoice/payment; missing transaction; incorrect tax/exchange rate/date; backdating — corrected via adjustment, reversal, credit note, debit note, or write-off, never a silent edit</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> a posted ABC Trading Ltd. invoice is discovered to reference the wrong customer a week after posting — walked through as a reversal plus correct re-issue, with the audit log showing both the original entry and the fix.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> a generic reconciliation diagram (Source A vs Source B → matched/unmatched → investigate → adjust → approve → resolved), reusable across all seven reconciliation types in Phase 30.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> "fixing" a posted error by editing the historical journal entry in place, breaking every report and audit trail that already referenced it.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 13 before it; Level 15 after it stress-tests this architecture against real, messy scenarios.</p>
+                </section>
+
+                <!-- LEVEL 15 -->
+                <section id="level-15">
+                    <div class="level-head"><span class="level-num">LEVEL 15</span><h3>Advanced ERP Accounting (Capstone)</h3></div>
+                    <p class="level-objective">Bring every prior level together against the full catalogue of real-world scenarios and close out the running ABC Trading Ltd. case study.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Phase</th><th>Prerequisites</th><th>Topics covered</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Phase 32</strong><br>Advanced Real-World Scenarios</td><td>Level 14</td><td>Partial/multiple/over/under-payment, advance, unallocated payment, reversal, refund, credit/debit note, discount, write-off, bad debt, payment gateway &amp; fee, bank fee, cash short/over, foreign currency, many-to-many allocation, intercompany payment, tax and period-end adjustment — each with business situation, documents, sequence, DR/CR, AR/AP impact, GL impact, settlement impact, and audit impact</td></tr>
+                            <tr><td><strong>Phase 34</strong><br>Workflow &amp; Diagram Guidance</td><td>Phase 32</td><td>Which diagram type (flowchart, activity, sequence, ERD, accounting-flow, lifecycle, posting, allocation, reconciliation) fits which topic, and what actors/documents/decision points/entities each must show</td></tr>
+                            <tr><td><strong>Phase 35</strong><br>Complete Business Case</td><td>Phase 34</td><td>ABC Trading Ltd., followed end-to-end from its opening balance through every phase above — the single running thread tying the entire curriculum together</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="meta-line"><strong>Business scenario:</strong> this level introduces no new numbers — it is where every prior level's ABC Trading Ltd. entries are assembled into one continuous general ledger and closed into one final set of financial statements.</p>
+                    <p class="meta-line"><strong>Diagram to build:</strong> none new — the deliverable is the assembled diagram library from every prior level, indexed against the one company.</p>
+                    <div class="warning-box"><strong>⚠️ Common mistake:</strong> treating "advanced scenarios" as edge cases to bolt on later instead of designing the Level 10 data model — many-to-many allocation, derived balances, typed adjustments — so that every one of these scenarios already falls out of it for free. That is exactly the conclusion reached in the <a href="erp-invoice-payment-architecture.html#scenario-playbook">scenario playbook</a> of the published Invoice vs Payment article.</div>
+                    <p class="connects-to"><strong>Connects to:</strong> Level 14 before it; nothing after it — this is the capstone the entire 15-level roadmap builds toward.</p>
+                </section>
+
+                <section id="content-template">
+                    <h2>📝 The Article Content Template</h2>
+                    <p>Every individual topic in the roadmap above expands into its own article using the same 28-field template, so the series reads as one consistent body of work no matter which topic or level a reader lands on first. The fields aren't arbitrary — most of them exist specifically to force the <a href="#six-perspectives">six perspectives</a> onto the page.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Field</th><th>Purpose</th></tr></thead>
+                        <tbody>
+                            <tr><td>Topic Number / Name</td><td>Position in the roadmap and a precise, searchable title</td></tr>
+                            <tr><td>Difficulty / Category</td><td>Which of the 15 levels it belongs to, and its phase grouping</td></tr>
+                            <tr><td>Prerequisites</td><td>Exact topics a reader must already know — never assumed silently</td></tr>
+                            <tr><td>Learning Objective</td><td>The one capability the reader should have by the end</td></tr>
+                            <tr><td>Why This Topic Matters</td><td>The real-world cost of getting it wrong</td></tr>
+                            <tr><td>Core / Accounting / ERP Concepts</td><td>Vocabulary introduced, split by traditional-accounting vs ERP-system framing</td></tr>
+                            <tr><td>Business Scenario / Numerical Example</td><td>Grounded in the ABC Trading Ltd. case study wherever possible</td></tr>
+                            <tr><td>Debit/Credit Concepts</td><td>The journal entry(ies) the scenario produces</td></tr>
+                            <tr><td>Documents Involved</td><td>Which business documents the topic touches (invoice, PO, GRN, etc.)</td></tr>
+                            <tr><td>Accounting Flow / ERP Workflow</td><td>Business Event → Document → Accounting Event → Journal Entry → GL, and who performs each step</td></tr>
+                            <tr><td>AR/AP Relationship / GL Relationship</td><td>How the topic affects subledger balances and the control accounts above them</td></tr>
+                            <tr><td>Financial Statement Impact</td><td>Which statement line moves, and in which direction</td></tr>
+                            <tr><td>Database Relationship</td><td>Conceptual entities and cardinalities — never production code</td></tr>
+                            <tr><td>Required Diagram</td><td>Which diagram type this topic needs (see <a href="#level-15">Level 15</a>, Phase 34)</td></tr>
+                            <tr><td>Common Mistakes</td><td>The specific, concrete failure mode — not generic advice</td></tr>
+                            <tr><td>Real-World ERP Scenario</td><td>How the concept shows up in a live system, not just in theory</td></tr>
+                            <tr><td>SAP / Odoo Conceptual Reference</td><td>Mapped per the <a href="#sap-odoo">comparison table</a> below — never fabricated</td></tr>
+                            <tr><td>Advanced Extension</td><td>Where the topic goes if the reader wants to go deeper immediately</td></tr>
+                            <tr><td>Related / Next Recommended Topic</td><td>Explicit links forward and sideways in the roadmap</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                </section>
+
+                <section id="sap-odoo">
+                    <h2>⚖️ SAP vs Odoo: Concept vs Vocabulary</h2>
+                    <p>These mappings are <strong>conceptual</strong> starting points for a writer, not a claim that SAP and Odoo implement the underlying process identically — they don't. Before any article asserts specific menu paths, transaction codes, or module names, verify them against current official SAP and Odoo documentation; product UIs and terminology change across versions.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Universal accounting concept</th><th>SAP-style framing</th><th>Odoo-style framing</th></tr></thead>
+                        <tbody>
+                            <tr><td>Customer / Supplier</td><td>Business Partner roles (Customer / Vendor)</td><td>A single <em>Contact</em> record flagged as Customer and/or Vendor</td></tr>
+                            <tr><td>Chart of Accounts</td><td>Operating Chart of Accounts assigned to a company code</td><td>Chart of Accounts assigned per company</td></tr>
+                            <tr><td>Journal Entry</td><td>Accounting Document / FI posting</td><td>Journal Entry (<em>move</em>) made of journal items</td></tr>
+                            <tr><td>Payment Allocation</td><td>Clearing open items against a payment document</td><td>Reconciling a payment move against an invoice move</td></tr>
+                            <tr><td>Reconciliation</td><td>Account clearing / open-item management</td><td>Bank/account reconciliation on a journal</td></tr>
+                            <tr><td>Tax handling</td><td>Tax procedure / condition-based tax determination</td><td>Fiscal Position mapping taxes and accounts</td></tr>
+                            <tr><td>Bank/Cash recording</td><td>Bank accounting sub-module (house banks)</td><td>Bank and Cash Journals</td></tr>
+                            <tr><td>Accounting Period</td><td>Posting period, opened/closed per company code</td><td>Fiscal Year with lock dates</td></tr>
+                            <tr><td>Cost Center / Analytic Accounting</td><td>Controlling (CO) cost centers &amp; profit centers</td><td>Analytic Accounts &amp; Analytic Tags</td></tr>
+                            <tr><td>Asset Accounting</td><td>Asset Accounting (FI-AA) sub-ledger</td><td>Assets module with depreciation boards</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <div class="warning-box">
+                        <strong>⚠️ Verification instruction for the writing agent:</strong> whenever a future article states a specific SAP or Odoo feature, screen, or field name, cross-check it against the current official documentation before publishing. Do not fabricate transaction codes, menu paths, or version-specific behavior — where uncertain, describe the concept generically and flag the product-specific detail as "verify against current docs."
+                    </div>
+                </section>
+
+                <section id="editorial-rules">
+                    <h2>✅ Editorial Guidelines for This Series</h2>
+                    <div class="success-box">
+                        <ul style="margin-bottom:0;">
+                            <li>Every article must explicitly answer all <a href="#six-perspectives">six perspectives</a> — Accountant, ERP User, ERP Functional, Accounting, System Architecture, Audit — not just the debit/credit one.</li>
+                            <li>Explain the business event before the journal entry it produces — never the reverse.</li>
+                            <li>Always show both the debit and the credit; never state one side alone.</li>
+                            <li>Distinguish <strong>document status</strong> from <strong>accounting status</strong> in every lifecycle discussion.</li>
+                            <li>Distinguish <strong>payment received</strong> from <strong>payment allocated</strong> — the single most common modeling error in the whole curriculum.</li>
+                            <li>Distinguish <strong>subledger</strong> balances from the <strong>General Ledger</strong> control account they roll up into.</li>
+                            <li>Cover both AR and AP, both Sales and Purchase — never document one side and assume the mirror is obvious.</li>
+                            <li>Explain every concept from both the accounting user's perspective and the ERP system's perspective.</li>
+                            <li>Never recommend deleting a posted transaction — teach reversal and correction instead.</li>
+                            <li>Never present SAP or Odoo terminology as if it were the universal accounting concept itself.</li>
+                            <li>Increase technical depth gradually — an advanced topic without its prerequisites linked is an incomplete article.</li>
+                        </ul>
+                    </div>
+                    <p>Together with the <a href="#content-template">content template</a> above, these rules are what keep a 35-phase, hundreds-of-topics series readable as one coherent body of work rather than a pile of disconnected posts — the same standard the <a href="erp-invoice-payment-architecture.html">Invoice vs Payment</a> article was written to.</p>
+
+                    <div class="mt-8 pt-6 border-t border-gray-200">
+                        <a href="blog.html" class="inline-flex items-center text-blue-600 hover:text-blue-800 font-semibold">
+                            ← Back to Blog
+                        </a>
+                    </div>
+                </section>
+            </article>
+        </div>
+    </main>
+
+    <!-- Back to Top Button -->
+    <div class="back-to-top" id="backToTop">
+        ↑
+    </div>
+
+    <!-- Footer -->
+<footer class="footer" style="margin-top: 60px;">
+<div class="container">
+  <div class="footer-inner">
+    <div class="footer-brand">
+      <strong>Md. Mostasim Mahmud Tasim</strong>
+      <p>Software Engineer</p>
+    </div>
+    <div class="footer-links">
+      <a href="https://github.com/tasim313" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/md-mostasim-mahmud-tasim" target="_blank">LinkedIn</a>
+      <a href="mailto:tasim.swe@gmail.com">Email</a>
+    </div>
+  </div>
+  <p class="footer-copy">&copy; 2026 Md. Mostasim Mahmud Tasim. All rights reserved.</p>
+</div>
+</footer>
+<script src="js/main.js"></script>
+<script>
+    document.querySelectorAll('pre').forEach(pre => {
+        pre.addEventListener('click', function() {
+            const code = this.textContent;
+            navigator.clipboard.writeText(code).then(() => {
+                const originalBg = this.style.backgroundColor;
+                this.style.backgroundColor = '#059669';
+                setTimeout(() => { this.style.backgroundColor = originalBg; }, 500);
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -136,6 +136,34 @@
 <div class="container">
   <div class="blog-grid">
 
+    <!-- Post -1 -->
+    <div class="blog-card fade-up">
+      <div class="blog-image placeholder"><i class="fa-solid fa-graduation-cap"></i></div>
+      <div class="blog-content">
+        <div class="blog-meta"><span class="tag">Accounting Curriculum</span><span>15 Levels · 35 Phases</span></div>
+        <h3>Accounting to ERP: The Complete Learning Roadmap</h3>
+        <p>A 15-level, 35-phase curriculum blueprint — from absolute-beginner bookkeeping to SAP/Odoo-style ERP accounting architecture — built around one running case study, ABC Trading Ltd.</p>
+        <div class="blog-footer">
+          <span class="blog-date">Aug 27, 2026</span>
+          <a href="accounting-erp-curriculum.html" class="blog-link">Read Article <i class="fa-solid fa-arrow-right"></i></a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Post 0 -->
+    <div class="blog-card fade-up">
+      <div class="blog-image placeholder"><i class="fa-solid fa-file-invoice-dollar"></i></div>
+      <div class="blog-content">
+        <div class="blog-meta"><span class="tag">ERP Accounting</span><span>28 min read</span></div>
+        <h3>Invoice vs Payment: The Complete ERP Accounting Architecture</h3>
+        <p>Entity relationship maps, workflow &amp; activity diagrams, a settlement decision flowchart, and a scenario playbook running a ৳1,000 invoice through 40+ real-world conditions — partial payments, overpayments, credit notes, write-offs, and reversals.</p>
+        <div class="blog-footer">
+          <span class="blog-date">Aug 27, 2026</span>
+          <a href="erp-invoice-payment-architecture.html" class="blog-link">Read Article <i class="fa-solid fa-arrow-right"></i></a>
+        </div>
+      </div>
+    </div>
+
     <!-- Post 1 -->
     <div class="blog-card fade-up">
       <div class="blog-image placeholder"><i class="fa-solid fa-database"></i></div>

--- a/erp-invoice-payment-architecture.html
+++ b/erp-invoice-payment-architecture.html
@@ -1,0 +1,977 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Invoice vs Payment: The Complete ERP Accounting Architecture | Md. Mostasim Mahmud Tasim</title>
+<meta name="description" content="Why invoices and payments are never the same transaction in SAP, Odoo, and Dynamics-style ERPs: double-entry accounting, AR/AP, allocation, reconciliation, and a production-ready database schema.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+<link rel="stylesheet" href="css/style.css">
+<style>
+/* Article Specific Styles */
+.article-container { max-width: 800px; margin: 0 auto; padding: 0 24px; }
+.article-content { font-size: 1.0625rem; line-height: 1.8; color: var(--text-secondary); }
+.article-content h2 { font-size: 2rem; margin-top: 3rem; margin-bottom: 1.5rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border); color: var(--text-primary); font-weight: 700; }
+.article-content h3 { font-size: 1.5rem; margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary); font-weight: 700; }
+.article-content h4 { font-size: 1.25rem; margin-top: 2rem; margin-bottom: 1rem; color: var(--text-primary); font-weight: 600; }
+.article-content p { margin-bottom: 1.5rem; }
+.article-content ul, .article-content ol { margin: 1.5rem 0; padding-left: 2rem; }
+.article-content li { margin-bottom: 0.5rem; }
+.article-content pre { background: #1a1a1a; color: #f8f8f2; padding: 1.5rem; border-radius: 8px; overflow-x: auto; margin: 1.5rem 0; font-family: 'Courier New', monospace; font-size: 0.875rem; line-height: 1.5; cursor: pointer; }
+.article-content code { background: var(--bg-alt); color: var(--text-primary); padding: 0.2rem 0.4rem; border-radius: 4px; font-family: 'Courier New', monospace; font-size: 0.875rem; }
+.article-content pre code { background: transparent; color: inherit; padding: 0; }
+.article-content blockquote { border-left: 4px solid var(--accent); padding-left: 1.5rem; margin: 2rem 0; font-style: italic; color: var(--text-secondary); background: var(--bg-alt); padding: 1.5rem; border-radius: 0 8px 8px 0; }
+.article-content table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.9375rem; }
+.article-content th, .article-content td { border: 1px solid var(--border); padding: 10px 14px; text-align: left; }
+.article-content th { background: var(--bg-alt); color: var(--text-primary); font-weight: 700; }
+.article-content table caption, .article-content .table-wrap { overflow-x: auto; }
+.info-box { background: var(--accent-subtle); border-left: 4px solid var(--accent); padding: 1.5rem; margin: 2rem 0; border-radius: 0 8px 8px 0; color: var(--text-primary); }
+.warning-box { background: #fff7ed; border-left: 4px solid #f97316; padding: 1.5rem; margin: 2rem 0; border-radius: 0 8px 8px 0; color: var(--text-primary); }
+.success-box { background: #f0fdf4; border-left: 4px solid #22c55e; padding: 1.5rem; margin: 2rem 0; border-radius: 0 8px 8px 0; color: var(--text-primary); }
+.table-of-contents { background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 1.5rem; margin: 2rem 0; border-radius: 0 12px 12px 0; }
+.table-of-contents ul { list-style: none; padding-left: 0; }
+.table-of-contents li { margin-bottom: 0.75rem; padding-left: 1.5rem; position: relative; }
+.table-of-contents li:before { content: "→"; position: absolute; left: 0; color: var(--accent); }
+.table-of-contents a { color: var(--accent); text-decoration: none; font-weight: 500; }
+.table-of-contents a:hover { text-decoration: underline; }
+header h1 { font-size: 2.5rem; font-weight: 800; color: var(--text-primary); line-height: 1.2; margin-bottom: 1.5rem; margin-top: 2rem; }
+header .category-badge { display: inline-block; background: var(--accent-subtle); color: var(--accent); padding: 6px 16px; border-radius: 20px; font-size: 0.8125rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+.reading-time { font-size: 0.875rem; color: var(--text-tertiary); font-weight: 500; }
+header p.text-center { text-align: center; margin-bottom: 1rem; color: var(--text-secondary); }
+
+/* Flow diagram (horizontal steps) */
+.diagram-scroll { overflow-x: auto; margin: 2rem 0; padding-bottom: 4px; }
+.flow-diagram { display: flex; align-items: stretch; gap: 0; min-width: min-content; }
+.flow-step { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; font-size: 0.8125rem; font-weight: 600; color: var(--text-primary); text-align: center; min-width: 128px; display: flex; flex-direction: column; justify-content: center; }
+.flow-step small { display: block; font-weight: 400; color: var(--text-tertiary); font-size: 0.6875rem; margin-top: 6px; line-height: 1.4; }
+.flow-arrow { display: flex; align-items: center; justify-content: center; color: var(--accent); font-size: 1.25rem; flex: 0 0 auto; padding: 0 10px; }
+
+/* Relationship / ER diagram */
+.rel-diagram { margin: 2rem 0; }
+.rel-layer { display: flex; flex-wrap: wrap; gap: 20px; justify-content: center; }
+.rel-connector { display: flex; justify-content: center; align-items: center; gap: 48px; padding: 10px 0; color: var(--accent); font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; text-align: center; }
+.rel-connector .arrow { font-size: 1.1rem; display: block; }
+.rel-entity { background: var(--bg-elevated); border: 1.5px solid var(--border); border-radius: 10px; min-width: 190px; max-width: 240px; overflow: hidden; flex: 1 1 200px; }
+.rel-entity h4 { margin: 0; padding: 10px 14px; background: var(--accent-subtle); color: var(--accent); font-size: 0.8125rem; font-weight: 700; border-bottom: 1px solid var(--border); }
+.rel-entity .rel-fields { list-style: none; margin: 0; padding: 10px 14px 4px; font-size: 0.6875rem; font-family: 'Courier New', monospace; color: var(--text-tertiary); }
+.rel-entity .rel-fields li { margin-bottom: 3px; }
+.rel-links { padding: 8px 14px 14px; display: flex; flex-wrap: wrap; gap: 6px; }
+.rel-link-tag { font-size: 0.625rem; font-weight: 600; background: var(--bg-alt); color: var(--text-secondary); border: 1px solid var(--border); padding: 3px 8px; border-radius: 12px; white-space: nowrap; }
+
+/* Activity / swimlane diagram */
+.activity-grid { display: grid; grid-template-columns: repeat(4, minmax(150px, 1fr)); gap: 10px 14px; min-width: 680px; }
+.activity-grid .lane-head { background: var(--bg-alt); border: 1px solid var(--border); border-radius: 8px; padding: 8px; text-align: center; font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--accent); }
+.step-card { background: var(--bg-elevated); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 8px; padding: 10px 12px; font-size: 0.75rem; line-height: 1.5; color: var(--text-primary); }
+.step-card .step-num { display: inline-flex; align-items: center; justify-content: center; background: var(--accent); color: #fff; font-size: 0.625rem; font-weight: 700; width: 18px; height: 18px; border-radius: 50%; margin-right: 6px; flex-shrink: 0; }
+.step-card .handoff-tag { display: block; margin-top: 6px; font-size: 0.625rem; font-weight: 600; color: var(--accent); }
+
+/* Decision flowchart */
+.decision-flow { display: flex; flex-direction: column; align-items: center; margin: 2rem 0; }
+.decision-node { background: var(--bg-elevated); border: 1.5px solid var(--border); border-radius: 8px; padding: 12px 20px; font-size: 0.8125rem; font-weight: 600; color: var(--text-primary); text-align: center; max-width: 340px; }
+.decision-flow .flow-arrow-down { color: var(--accent); font-size: 1.25rem; padding: 4px 0; }
+.decision-row { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; justify-content: center; }
+.decision-diamond { width: 132px; height: 132px; background: var(--accent-subtle); border: 2px solid var(--accent); transform: rotate(45deg); border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.decision-diamond span { transform: rotate(-45deg); font-size: 0.75rem; font-weight: 700; text-align: center; color: var(--text-primary); padding: 10px; line-height: 1.3; }
+.decision-branch-note { background: var(--bg-alt); border: 1px dashed var(--border); border-radius: 8px; padding: 10px 14px; font-size: 0.75rem; color: var(--text-secondary); max-width: 260px; }
+.decision-branch-note strong { color: var(--accent); }
+.decision-end { background: var(--accent); color: #fff; border-radius: 8px; padding: 12px 20px; font-size: 0.8125rem; font-weight: 700; text-align: center; max-width: 340px; }
+</style>
+</head>
+<body>
+<!-- Navigation -->
+<nav class="nav" role="navigation">
+<div class="nav-inner">
+  <a href="index.html" class="nav-brand">Mostasim Mahmud Tasim</a>
+  <ul class="nav-links">
+    <li><a href="index.html#about">About</a></li>
+    <li><a href="index.html#experience">Experience</a></li>
+    <li><a href="index.html#capabilities">Engineering</a></li>
+    <li><a href="index.html#projects">Projects</a></li>
+    <li><a href="index.html#infrastructure">Infrastructure</a></li>
+    <li><a href="blog.html">Blog</a></li>
+    <li><a href="index.html#contact">Contact</a></li>
+  </ul>
+  <div class="nav-actions">
+    <a href="https://github.com/tasim313" class="nav-ext" target="_blank"><i class="fa-brands fa-github"></i></a>
+    <a href="https://www.linkedin.com/in/md-mostasim-mahmud-tasim" class="nav-ext" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
+    <button class="theme-toggle" id="themeToggle"><svg id="sunIcon" style="display:none" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg><svg id="moonIcon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg></button>
+    <button class="mobile-toggle" id="mobileToggle"><span></span><span></span><span></span></button>
+  </div>
+</div>
+</nav>
+<div class="mobile-menu" id="mobileMenu">
+  <a href="index.html#about">About</a>
+  <a href="index.html#experience">Experience</a>
+  <a href="index.html#capabilities">Engineering</a>
+  <a href="index.html#projects">Projects</a>
+  <a href="index.html#infrastructure">Infrastructure</a>
+  <a href="blog.html">Blog</a>
+  <a href="index.html#contact">Contact</a>
+</div>
+
+    <!-- Article Header -->
+    <header class="pt-12 pb-8">
+        <div class="article-container">
+            <div class="text-center mb-8">
+                <span class="category-badge">ERP Accounting Architecture</span>
+                <span class="reading-time ml-4">📖 28 min read</span>
+            </div>
+
+            <h1>Invoice vs Payment: The Complete ERP Accounting Architecture</h1>
+
+            <div class="text-center text-gray-600 mb-8">
+                <p class="text-sm">Published: <span class="font-semibold">Aug 27, 2026</span></p>
+            </div>
+        </div>
+    </header>
+
+    <!-- Main Article Content -->
+    <main class="pb-16">
+        <div class="article-container">
+            <!-- Table of Contents -->
+            <div class="table-of-contents fade-in">
+                <h3 class="font-bold text-lg mb-4 text-gray-800">📋 Table of Contents</h3>
+                <ul class="space-y-2">
+                    <li><a href="#core-concept">The Core Concept: Invoice = Obligation, Payment = Settlement</a></li>
+                    <li><a href="#relationship-diagram">How It Works: The Entity Relationship Map</a></li>
+                    <li><a href="#sales-flow">Sales Flow: Order → Delivery → Invoice → Payment</a></li>
+                    <li><a href="#purchase-flow">Purchase Flow: PO → Receipt → Vendor Bill → Payment</a></li>
+                    <li><a href="#activity-diagram">Activity Diagram: The Invoice-to-Cash Swimlane</a></li>
+                    <li><a href="#ar-ap">Accounts Receivable &amp; Accounts Payable</a></li>
+                    <li><a href="#double-entry">Double-Entry Accounting Fundamentals</a></li>
+                    <li><a href="#journal-entries">Journal Entries &amp; the General Ledger</a></li>
+                    <li><a href="#allocation">Payment Allocation: Many-to-Many by Design</a></li>
+                    <li><a href="#reconciliation">Reconciliation</a></li>
+                    <li><a href="#lifecycle">Invoice &amp; Payment Lifecycle</a></li>
+                    <li><a href="#status-matrix">The Multi-Dimensional Status Model</a></li>
+                    <li><a href="#decision-flowchart">Flowchart: The Settlement Decision Logic</a></li>
+                    <li><a href="#edge-cases">Credit Notes, Refunds, Overpayments &amp; Advances</a></li>
+                    <li><a href="#scenario-playbook">Scenario Playbook: A ৳1,000 Invoice Under 40+ Conditions</a></li>
+                    <li><a href="#three-way-matching">Three-Way Matching</a></li>
+                    <li><a href="#audit-trail">Audit Trail: Why You Never Delete Posted Documents</a></li>
+                    <li><a href="#schema">Recommended Database Schema (Django/PostgreSQL)</a></li>
+                    <li><a href="#chart-of-accounts">Chart of Accounts &amp; Control Accounts</a></li>
+                    <li><a href="#best-practices">Best Practices Checklist</a></li>
+                </ul>
+            </div>
+
+            <!-- Article Content -->
+            <article class="article-content fade-in">
+
+                <section id="core-concept">
+                    <h2>📌 The Core Concept: Invoice = Obligation, Payment = Settlement</h2>
+                    <p>In ERP systems such as SAP, Odoo, Microsoft Dynamics, and any serious custom-built ERP, <strong>Invoice and Payment are related but they are never the same transaction</strong>. An invoice creates a <strong>financial obligation</strong>. A payment <strong>settles that obligation</strong>. Conflating the two is one of the most common design mistakes when building an ERP or POS from scratch.</p>
+                    <p>A simple business transaction unfolds like this:</p>
+                    <pre><code>Customer buys goods → Sale happens → Invoice is created
+→ Customer owes money → Customer pays → Payment is recorded
+→ Invoice becomes paid
+
+Sale/Order → Invoice → Receivable → Payment → Reconciliation → Invoice Paid</code></pre>
+                    <p>For a supplier, the mirror image applies: <code>Purchase/Order → Vendor Bill → Payable → Payment → Reconciliation → Bill Paid</code>.</p>
+
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Concept</th><th>Invoice</th><th>Payment</th></tr></thead>
+                        <tbody>
+                            <tr><td>Meaning</td><td>Money that is owed</td><td>Money that has actually moved</td></tr>
+                            <tr><td>Creates obligation?</td><td>Yes</td><td>No</td></tr>
+                            <tr><td>Customer side</td><td>Accounts Receivable</td><td>Receives money</td></tr>
+                            <tr><td>Supplier side</td><td>Accounts Payable</td><td>Pays money</td></tr>
+                            <tr><td>Can exist without the other?</td><td>Yes</td><td>Yes</td></tr>
+                            <tr><td>Changes outstanding balance?</td><td>Creates balance</td><td>Reduces balance</td></tr>
+                            <tr><td>Status values</td><td>Draft, Posted, Partially Paid, Paid, Cancelled</td><td>Pending, Posted, Reconciled, Cancelled</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <div class="info-box">
+                        <strong>💡 The one-line rule:</strong> An ERP should never think <code>Invoice → Payment</code> directly. It should think <code>Business Transaction → Document → Accounting Document → Receivable/Payable → Payment → Reconciliation</code>.
+                    </div>
+                </section>
+
+                <section id="relationship-diagram">
+                    <h2>🗺️ How It Works: The Entity Relationship Map</h2>
+                    <p>Before any workflow or flowchart makes sense, the underlying <strong>relationships</strong> have to be right. The single biggest mistake is wiring <code>Invoice</code> and <code>Payment</code> together with a direct foreign key. In a real ERP, nothing connects to a payment directly — everything passes through an <strong>allocation</strong> record, and every posted document mirrors itself into a <strong>journal entry</strong>. The map below shows the actual shape of the data for the customer/sales side (the supplier/purchase side is the exact mirror image, with <code>Supplier</code>, <code>VendorBill</code> and <code>Accounts Payable</code> in place of <code>Customer</code>, <code>Invoice</code> and <code>Accounts Receivable</code>).</p>
+
+                    <div class="rel-diagram">
+                        <div class="rel-layer">
+                            <div class="rel-entity">
+                                <h4>Customer</h4>
+                                <ul class="rel-fields">
+                                    <li>id</li><li>name</li><li>credit_terms</li><li>credit_limit</li>
+                                </ul>
+                                <div class="rel-links">
+                                    <span class="rel-link-tag">1 → N Invoice</span>
+                                    <span class="rel-link-tag">1 → N Payment</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="rel-connector"><span class="arrow">↓ ↓</span>creates (1 : N)</div>
+                        <div class="rel-layer">
+                            <div class="rel-entity">
+                                <h4>Invoice</h4>
+                                <ul class="rel-fields">
+                                    <li>id, number, total</li><li>status, due_date</li>
+                                </ul>
+                                <div class="rel-links">
+                                    <span class="rel-link-tag">N → 1 Customer</span>
+                                    <span class="rel-link-tag">1 → N InvoiceLine</span>
+                                    <span class="rel-link-tag">1 → 1 JournalEntry</span>
+                                </div>
+                            </div>
+                            <div class="rel-entity">
+                                <h4>Payment</h4>
+                                <ul class="rel-fields">
+                                    <li>id, amount, method</li><li>status, reference</li>
+                                </ul>
+                                <div class="rel-links">
+                                    <span class="rel-link-tag">N → 1 Customer</span>
+                                    <span class="rel-link-tag">1 → 1 JournalEntry</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="rel-connector"><span class="arrow">↓ ↓</span>N : M — resolved through</div>
+                        <div class="rel-layer">
+                            <div class="rel-entity">
+                                <h4>PaymentAllocation</h4>
+                                <ul class="rel-fields">
+                                    <li>invoice_id (FK)</li><li>payment_id (FK)</li><li>allocated_amount</li>
+                                </ul>
+                                <div class="rel-links">
+                                    <span class="rel-link-tag">N → 1 Invoice</span>
+                                    <span class="rel-link-tag">N → 1 Payment</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="rel-connector"><span class="arrow">↓</span>settles → derives</div>
+                        <div class="rel-layer">
+                            <div class="rel-entity">
+                                <h4>Reconciliation</h4>
+                                <ul class="rel-fields">
+                                    <li>ar_debit_je_id</li><li>ar_credit_je_id</li>
+                                </ul>
+                                <div class="rel-links">
+                                    <span class="rel-link-tag">outstanding = Σ debits − Σ credits</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="rel-connector"><span class="arrow">↓</span>posts to</div>
+                        <div class="rel-layer">
+                            <div class="rel-entity">
+                                <h4>General Ledger</h4>
+                                <ul class="rel-fields">
+                                    <li>account_id</li><li>debit / credit</li>
+                                </ul>
+                                <div class="rel-links">
+                                    <span class="rel-link-tag">AR control = Σ customer balances</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="info-box">
+                        <strong>💡 Basic concept:</strong> An <code>Invoice</code> is a record of an <em>obligation</em>; a <code>Payment</code> is a record of <em>money movement</em>. Neither one "contains" the other — they are two independent facts joined by a third record, <code>PaymentAllocation</code>, which is the only place the ERP is allowed to say "this much of that payment settles this much of that invoice."<br><br>
+                        <strong>🧠 Main concept:</strong> Every balance you display to a user — outstanding amount, PAID/PARTIAL status, customer statement — is <em>derived</em> at read time from the chain <code>Invoice → PaymentAllocation → Reconciliation → GL</code>. Nothing is hard-coded as a single mutable field that different modules race to update.
+                    </div>
+                </section>
+
+                <section id="sales-flow">
+                    <h2>🛒 Sales Flow: Order → Delivery → Invoice → Payment</h2>
+                    <p>Sales is the commercial side of the transaction — it answers <em>what did we sell, to whom, and on what terms</em>. Not every ERP needs every step; a simple POS can collapse straight to <code>Sale → Invoice → Payment</code>, while an enterprise flow keeps every stage distinct and auditable.</p>
+
+                    <div class="diagram-scroll">
+                        <div class="flow-diagram">
+                            <div class="flow-step">Quotation<small>commercial offer, no financial impact</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Sales Order<small>commitment — NOT yet a receivable</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Delivery<small>stock −, COGS may post</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Invoice<small>obligation created — AR +</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Payment<small>money received</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Allocation<small>payment ↔ invoice link</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Reconciled<small>AR − , Invoice = PAID</small></div>
+                        </div>
+                    </div>
+
+                    <p>Worked example — a customer buys ৳10,000 of goods on credit:</p>
+                    <pre><code>Invoice INV-00001
+Subtotal      ৳9,000
+VAT           ৳1,000
+---------------------
+Total        ৳10,000
+
+Journal Entry:
+  DR Accounts Receivable    10,000
+      CR Sales Revenue                9,000
+      CR VAT Payable                  1,000
+
+Customer pays ৳4,000 (partial):
+  DR Cash                    4,000
+      CR Accounts Receivable          4,000
+
+Outstanding = 10,000 - 4,000 = 6,000  →  status: PARTIALLY PAID
+
+Customer pays remaining ৳6,000:
+  DR Cash                    6,000
+      CR Accounts Receivable          6,000
+
+Outstanding = 0  →  status: PAID</code></pre>
+                    <div class="warning-box">
+                        <strong>⚠️ Order ≠ Invoice ≠ Payment.</strong> An Order is a commitment ("I want to buy"). An Invoice is an obligation ("you owe me money"). A Payment is a settlement ("money has been received"). Treating a Sales Order as if it already creates a receivable is a common and costly modeling bug.
+                    </div>
+                </section>
+
+                <section id="purchase-flow">
+                    <h2>📦 Purchase Flow: PO → Receipt → Vendor Bill → Payment</h2>
+                    <p>The purchase side mirrors sales exactly, but from the supplier's perspective:</p>
+
+                    <div class="diagram-scroll">
+                        <div class="flow-diagram">
+                            <div class="flow-step">Purchase Request<small>internal need identified</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Purchase Order<small>commitment — NOT yet payable</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Goods Receipt<small>stock +, GRNI accrues</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Vendor Bill<small>obligation created — AP +</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Payment<small>money paid</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Allocation<small>payment ↔ bill link</small></div>
+                            <div class="flow-arrow">→</div>
+                            <div class="flow-step">Reconciled<small>AP − , Bill = PAID</small></div>
+                        </div>
+                    </div>
+
+                    <p>Because goods receipt and vendor billing can arrive at different times, mature ERPs also track <strong>Goods Received Not Invoiced (GRNI)</strong> as an accrued liability until the vendor bill lands.</p>
+                    <pre><code>Vendor Bill
+Goods       ৳100,000
+VAT          ৳15,000
+---------------------
+Total       ৳115,000
+
+  DR Inventory / Expense    100,000
+  DR Input VAT               15,000
+      CR Accounts Payable            115,000
+
+Payment 1 = ৳80,000
+Payment 2 = ৳35,000
+------------------------
+Outstanding = 0  →  status: PAID</code></pre>
+                </section>
+
+                <section id="activity-diagram">
+                    <h2>🏊 Activity Diagram: The Invoice-to-Cash Swimlane</h2>
+                    <p>A flow diagram shows <em>what</em> happens to the documents. An activity diagram shows <em>who</em> does each step and where responsibility hands off between actors — the Customer, Sales, Accounting, and Finance. Read the numbered cards left-to-right, top-to-bottom; each <strong>handoff tag</strong> is where the process crosses into the next lane.</p>
+
+                    <div class="diagram-scroll">
+                        <div class="activity-grid">
+                            <div class="lane-head">Customer</div>
+                            <div class="lane-head">Sales</div>
+                            <div class="lane-head">Accounting</div>
+                            <div class="lane-head">Finance</div>
+
+                            <div class="step-card" style="grid-column:1; grid-row:2;"><span class="step-num">1</span>Places a Sales Order<span class="handoff-tag">↷ hands off to Sales</span></div>
+
+                            <div class="step-card" style="grid-column:2; grid-row:3;"><span class="step-num">2</span>Confirms order, arranges delivery<span class="handoff-tag">↷ hands off to Sales</span></div>
+
+                            <div class="step-card" style="grid-column:2; grid-row:4;"><span class="step-num">3</span>Creates &amp; posts the Invoice<span class="handoff-tag">↷ hands off to Accounting</span></div>
+
+                            <div class="step-card" style="grid-column:3; grid-row:5;"><span class="step-num">4</span>Posts AR journal entry<br><small style="color:var(--text-tertiary)">DR Accounts Receivable / CR Revenue</small><span class="handoff-tag">✓ AR created</span></div>
+
+                            <div class="step-card" style="grid-column:1; grid-row:6;"><span class="step-num">5</span>Makes a payment (cash / bank / gateway)<span class="handoff-tag">↷ hands off to Finance</span></div>
+
+                            <div class="step-card" style="grid-column:4; grid-row:7;"><span class="step-num">6</span>Receives &amp; posts the payment<br><small style="color:var(--text-tertiary)">DR Cash/Bank / CR AR (pre-allocation)</small><span class="handoff-tag">↷ hands off to Accounting</span></div>
+
+                            <div class="step-card" style="grid-column:3; grid-row:8;"><span class="step-num">7</span>Allocates payment to invoice &amp; reconciles AR<span class="handoff-tag">✓ AR = 0</span></div>
+
+                            <div class="step-card" style="grid-column:1; grid-row:9;"><span class="step-num">8</span>Sees invoice status = PAID on their statement</div>
+                        </div>
+                    </div>
+                    <p style="margin-top:1.5rem;">Notice that <strong>Accounting</strong> touches the process twice — once to record the obligation (step 4) and once to record the settlement (step 7) — and that neither touch is triggered by the other directly. Each is triggered by its own upstream document (the Invoice, then the Payment), which is exactly why the two must stay independent tables joined by an allocation record, as shown in the <a href="#relationship-diagram">relationship map</a> above.</p>
+                </section>
+
+                <section id="ar-ap">
+                    <h2>💳 Accounts Receivable &amp; Accounts Payable</h2>
+                    <p><strong>AR</strong> is money customers owe your company. <strong>AP</strong> is money your company owes suppliers. Neither is simply a flag on the <code>invoice</code> table — each is effectively a <strong>subledger</strong>: a running balance per business partner, derived from every invoice, credit note, and payment posted against them.</p>
+                    <pre><code>Customer A statement
+Opening Balance          ৳0
++ Invoice 1          ৳100,000
++ Invoice 2           ৳50,000
+- Payment             ৳80,000
+-----------------------------
+Closing Balance        ৳70,000</code></pre>
+                    <p>The AR subledger total must always reconcile with the AR <strong>control account</strong> in the General Ledger:</p>
+                    <pre><code>SUM(all customer balances)  =  GL "Accounts Receivable" balance
+SUM(all supplier balances)  =  GL "Accounts Payable" balance</code></pre>
+                </section>
+
+                <section id="double-entry">
+                    <h2>⚖️ Double-Entry Accounting Fundamentals</h2>
+                    <p>Every financial event must have equal total debits and credits. This single invariant is what keeps an ERP's books internally consistent no matter how many modules write to them.</p>
+                    <pre><code>Assets = Liabilities + Equity + Revenue - Expenses</code></pre>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Account type</th><th>Increase</th><th>Decrease</th></tr></thead>
+                        <tbody>
+                            <tr><td>Asset</td><td>Debit</td><td>Credit</td></tr>
+                            <tr><td>Expense</td><td>Debit</td><td>Credit</td></tr>
+                            <tr><td>Liability</td><td>Credit</td><td>Debit</td></tr>
+                            <tr><td>Equity</td><td>Credit</td><td>Debit</td></tr>
+                            <tr><td>Revenue</td><td>Credit</td><td>Debit</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p>"Debit = increase, credit = decrease" is a common misconception — it depends entirely on the account type, as the table above shows. A few canonical entries:</p>
+                    <pre><code># Sale on credit
+DR Accounts Receivable
+    CR Sales Revenue
+
+# Cash received against an invoice
+DR Cash
+    CR Accounts Receivable
+
+# Pay a supplier
+DR Accounts Payable
+    CR Bank</code></pre>
+                    <div class="warning-box">
+                        <strong>⚠️ Payment never re-creates revenue.</strong> Revenue is recognized once, when the invoice posts. A payment only moves value from Accounts Receivable to Bank/Cash — recording it as revenue again double-counts the sale.
+                    </div>
+                </section>
+
+                <section id="journal-entries">
+                    <h2>📒 Journal Entries &amp; the General Ledger</h2>
+                    <p>Every financial event should ultimately become a journal entry — the accounting truth behind the business document.</p>
+                    <pre><code>JE-2026-000001
+Date: 27-Aug-2026          Reference: INV-2026-001
+
+Account                       Debit       Credit
+--------------------------------------------------
+Accounts Receivable          55,000
+Sales Revenue                             50,000
+VAT Payable                                5,000
+--------------------------------------------------
+TOTAL                        55,000       55,000</code></pre>
+                    <p>A clean schema separates the journal entry header from its lines, because one entry always has two or more balanced lines:</p>
+                    <pre><code>journal_entry
+--------------------------
+id
+date
+reference
+source_type      -- e.g. "invoice", "payment", "credit_note"
+source_id
+description
+status
+posted_at
+
+journal_entry_line
+--------------------------
+id
+journal_entry_id  (FK)
+account_id         (FK -> chart of accounts)
+debit
+credit
+partner_id
+currency
+exchange_rate</code></pre>
+                    <p>The <strong>General Ledger</strong> is simply the aggregation of every posted journal entry line, grouped by account:</p>
+                    <pre><code>Business Document (Invoice / Payment / Bill)
+        ↓
+Accounting Event
+        ↓
+Journal Entry (balanced: total debit = total credit)
+        ↓
+General Ledger</code></pre>
+                </section>
+
+                <section id="allocation">
+                    <h2>🔗 Payment Allocation: Many-to-Many by Design</h2>
+                    <p>This is the concept most custom ERPs get wrong first. Don't model <code>invoice.payment_id</code> as a one-to-one link — in reality, <strong>one invoice can be settled by many payments</strong>, and <strong>one payment can settle many invoices</strong>.</p>
+                    <pre><code>Invoice INV-001                    Payment PAY-1001
+Total = ৳100,000                   Amount = ৳100,000
+                                           │
+├── Payment 1 = ৳30,000                    ├── Invoice A → ৳40,000
+├── Payment 2 = ৳20,000                    ├── Invoice B → ৳35,000
+└── Payment 3 = ৳50,000                    └── Invoice C → ৳25,000
+
+Total Paid = ৳100,000               (Payment applied across 3 invoices)
+Balance = ৳0</code></pre>
+                    <p>The relationship <code>Invoice ←→ Payment</code> is therefore <strong>many-to-many</strong>, resolved through an allocation table:</p>
+                    <pre><code>payment
+----------------
+id
+customer_id
+payment_date
+amount
+payment_method
+bank_account_id
+reference
+status
+
+payment_allocation
+------------------
+id
+payment_id     (FK)
+invoice_id     (FK)
+allocated_amount
+allocation_date</code></pre>
+                    <p>If a payment isn't fully allocated — say a customer pays ৳100,000 against ৳90,000 of open invoices — the remaining ৳10,000 becomes an <strong>on-account credit balance</strong> rather than being force-fit onto an invoice it doesn't belong to.</p>
+                </section>
+
+                <section id="reconciliation">
+                    <h2>🧮 Reconciliation</h2>
+                    <p>Allocation and reconciliation are related but distinct. <strong>Allocation</strong> answers <em>how much of this payment applies to this invoice?</em> <strong>Reconciliation</strong> answers <em>which AR journal entries offset each other?</em></p>
+                    <pre><code>Invoice Journal Entry:   AR  +100,000
+Payment Journal Entry:   AR  -100,000
+                              ────────
+Reconciled AR balance:          0     →  Invoice = PAID</code></pre>
+                    <p>Partial reconciliation works the same way, just leaving a remainder:</p>
+                    <pre><code>AR Debit  (invoice)     100,000
+AR Credit (payment)      40,000
+-------------------------------
+Remaining outstanding    60,000   →  status: PARTIALLY PAID</code></pre>
+                </section>
+
+                <section id="lifecycle">
+                    <h2>🔄 Invoice &amp; Payment Lifecycle</h2>
+                    <p>A professional ERP derives status from a controlled state machine rather than letting any code path set <code>status</code> freely.</p>
+                    <pre><code>Invoice lifecycle                    Payment lifecycle
+
+DRAFT                                 Created
+  ↓                                     ↓
+CONFIRMED                             Pending
+  ↓                                     ↓
+POSTED  ──► JOURNAL ENTRY             Posted
+  ↓                                     ↓
+OUTSTANDING                           Allocated
+  ↓ (payment received)                  ↓
+PARTIALLY PAID                        Reconciled
+  ↓ (fully allocated)
+PAID</code></pre>
+                    <p>The outstanding balance is always <em>derived</em>, never stored as a naive flag:</p>
+                    <pre><code>Outstanding Balance =
+      Invoice Total
+    - Credit Notes
+    - Allocated Payments
+    + Debit Adjustments
+
+Outstanding = 0  →  PAID</code></pre>
+                </section>
+
+                <section id="status-matrix">
+                    <h2>🎛️ The Multi-Dimensional Status Model</h2>
+                    <p>A common mistake is cramming everything into one <code>invoice.status</code> field. In practice an invoice has <strong>four independent dimensions</strong> — whether the document itself is finalized, how much of it is settled, whether it's overdue, and (separately) where the payment that's settling it stands. Mixing them together produces states like <code>"overdue_partial_cancelled"</code> that are impossible to query cleanly.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Dimension</th><th>Applies to</th><th>Possible values</th><th>What it answers</th></tr></thead>
+                        <tbody>
+                            <tr><td><strong>Document status</strong></td><td>Invoice / Bill</td><td>DRAFT, CONFIRMED, POSTED, CANCELLED, REVERSED</td><td>Is the document itself finalized and posted to the ledger?</td></tr>
+                            <tr><td><strong>Settlement status</strong></td><td>Invoice / Bill</td><td>UNPAID, PARTIALLY_PAID, PAID, OVERPAID, WRITTEN_OFF, CREDITED</td><td>How much of the obligation has actually been cleared?</td></tr>
+                            <tr><td><strong>Due status</strong></td><td>Invoice / Bill</td><td>NOT_DUE, DUE_TODAY, OVERDUE</td><td>Has the payment-term deadline passed?</td></tr>
+                            <tr><td><strong>Payment status</strong></td><td>Payment</td><td>DRAFT, PENDING, POSTED, PARTIALLY_ALLOCATED, FULLY_ALLOCATED, REVERSED, CANCELLED, FAILED</td><td>Where does the payment itself stand, independent of which invoice(s) it touches?</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <div class="info-box">
+                        <strong>💡 Why it matters:</strong> a real invoice can be <code>POSTED</code> + <code>PARTIALLY_PAID</code> + <code>OVERDUE</code> all at once — three true facts, three separate columns (or derived properties), each independently queryable for reporting, dunning, and aging without regex-parsing a single mashed-together string.
+                    </div>
+                </section>
+
+                <section id="decision-flowchart">
+                    <h2>🔀 Flowchart: The Settlement Decision Logic</h2>
+                    <p>This is the actual decision tree an ERP runs every time a payment is recorded against an invoice — the logic behind the <a href="#lifecycle">lifecycle</a> and the <a href="#status-matrix">status model</a> above, made explicit.</p>
+
+                    <div class="decision-flow">
+                        <div class="decision-node">Invoice Posted<br><small style="font-weight:400;color:var(--text-tertiary);">AR + Invoice Total</small></div>
+                        <div class="flow-arrow-down">↓</div>
+
+                        <div class="decision-row">
+                            <div class="decision-diamond"><span>Payment received?</span></div>
+                            <div class="decision-branch-note"><strong>No →</strong> stays OUTSTANDING. If due_date has passed, also flag OVERDUE (an independent dimension — see the status model).</div>
+                        </div>
+                        <div class="flow-arrow-down">↓ Yes</div>
+
+                        <div class="decision-node">Record Payment<br><small style="font-weight:400;color:var(--text-tertiary);">create PaymentAllocation against the invoice</small></div>
+                        <div class="flow-arrow-down">↓</div>
+
+                        <div class="decision-row">
+                            <div class="decision-diamond"><span>Allocated &lt; Outstanding?</span></div>
+                            <div class="decision-branch-note"><strong>Yes →</strong> Settlement status = PARTIALLY_PAID. AR reduced by the allocated amount; remainder stays open for the next payment.</div>
+                        </div>
+                        <div class="flow-arrow-down">↓ No</div>
+
+                        <div class="decision-row">
+                            <div class="decision-diamond"><span>Allocated &gt; Outstanding?</span></div>
+                            <div class="decision-branch-note"><strong>Yes →</strong> Overpayment. Allocate only up to the outstanding balance; park the excess as a Customer Credit / on-account balance.</div>
+                        </div>
+                        <div class="flow-arrow-down">↓ No (exactly equal)</div>
+
+                        <div class="decision-end">Outstanding = 0 → Settlement status = PAID<br>Reconciliation posted to the General Ledger</div>
+                    </div>
+                </section>
+
+                <section id="edge-cases">
+                    <h2>🧾 Credit Notes, Refunds, Overpayments &amp; Advances</h2>
+                    <h3>Credit note</h3>
+                    <p>Never edit a posted invoice to reflect a return. Issue a credit note instead, preserving the audit trail:</p>
+                    <pre><code>Original Invoice       ৳100,000
+Credit Note              -৳20,000
+----------------------------------
+Net Receivable            ৳80,000</code></pre>
+                    <h3>Refund</h3>
+                    <p>Different from a credit note — the ERP should preserve all three transactions rather than netting them away:</p>
+                    <pre><code>Invoice        ৳100,000
+Paid           ৳100,000
+Refund          -৳20,000
+--------------------------
+Net received     ৳80,000</code></pre>
+                    <h3>Overpayment</h3>
+                    <pre><code>Invoice  = ৳10,000
+Payment  = ৳15,000
+
+Allocation to invoice = ৳10,000  →  invoice PAID
+Unallocated           =  ৳5,000  →  customer on-account credit</code></pre>
+                    <h3>Advance payment</h3>
+                    <p>Customers can pay before an invoice even exists — the advance becomes a credit that later invoices draw down:</p>
+                    <pre><code>Advance payment          ৳50,000  →  Customer Credit
+Later invoice             ৳80,000
+Applied from advance     -৳50,000
+--------------------------------------
+Outstanding remaining     ৳30,000</code></pre>
+                </section>
+
+                <section id="scenario-playbook">
+                    <h2>🧪 Scenario Playbook: A ৳1,000 Invoice Under 40+ Conditions</h2>
+                    <p>The formula from the <a href="#lifecycle">lifecycle</a> section — <code>Outstanding = Invoice Total − Credits/Adjustments − Allocated Payments + Debit Adjustments</code> — has to survive every real condition a customer, cashier, or bank can throw at it. Below is a single ৳1,000 invoice run through the full range of scenarios an ERP must handle correctly. The same logic mirrors exactly onto the AP/supplier side.</p>
+
+                    <h3>1. Partial payment progression</h3>
+                    <p>The core case: any amount between ৳0 and ৳1,000 leaves the invoice <code>PARTIALLY_PAID</code> — there is no special threshold at 25%, 50%, or 90%. Only <code>Outstanding = 0</code> flips it to <code>PAID</code>.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Paid</th><th>% of invoice</th><th>Outstanding</th><th>Settlement status</th></tr></thead>
+                        <tbody>
+                            <tr><td>৳0</td><td>0%</td><td>৳1,000</td><td>UNPAID</td></tr>
+                            <tr><td>৳10</td><td>1%</td><td>৳990</td><td>PARTIALLY_PAID</td></tr>
+                            <tr><td>৳100</td><td>10%</td><td>৳900</td><td>PARTIALLY_PAID</td></tr>
+                            <tr><td>৳250</td><td>25%</td><td>৳750</td><td>PARTIALLY_PAID</td></tr>
+                            <tr><td>৳500</td><td>50%</td><td>৳500</td><td>PARTIALLY_PAID</td></tr>
+                            <tr><td>৳900</td><td>90%</td><td>৳100</td><td>PARTIALLY_PAID</td></tr>
+                            <tr><td>৳999</td><td>99.9%</td><td>৳1</td><td>PARTIALLY_PAID</td></tr>
+                            <tr><td>৳1,000</td><td>100%</td><td>৳0</td><td><strong>PAID</strong></td></tr>
+                            <tr><td>৳1,200</td><td>120%</td><td>৳0</td><td><strong>PAID</strong> + ৳200 customer credit</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <h3>2. Many payments settling one invoice</h3>
+                    <p>There is no limit on how many payments can close one invoice — the allocation table simply accumulates rows until the sum reaches the total.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Breakdown</th><th>Payments</th><th>Sum</th><th>Result</th></tr></thead>
+                        <tbody>
+                            <tr><td>Two payments</td><td>600 + 400</td><td>1,000</td><td>PAID</td></tr>
+                            <tr><td>Three installments</td><td>300 + 300 + 400</td><td>1,000</td><td>PAID</td></tr>
+                            <tr><td>Four equal installments</td><td>250 × 4</td><td>1,000</td><td>PAID</td></tr>
+                            <tr><td>Eight small receipts</td><td>50+50+50+100+150+200+200+200</td><td>1,000</td><td>PAID</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <h3>3. One payment settling many invoices</h3>
+                    <p>The mirror case, exercising the many-to-many allocation from the <a href="#allocation">allocation</a> section.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Open invoices</th><th>Payment</th><th>Allocation</th><th>Result</th></tr></thead>
+                        <tbody>
+                            <tr><td>A=1,000, B=2,000, C=3,000</td><td>৳4,000</td><td>A→1,000, B→2,000, C→1,000</td><td>A, B PAID; C PARTIALLY_PAID (2,000 left)</td></tr>
+                            <tr><td>A=1,000, B=1,000</td><td>৳1,500</td><td>A→1,000, B→500</td><td>A PAID; B PARTIALLY_PAID (500 left)</td></tr>
+                            <tr><td>A=1,000, B=2,000, C=3,000</td><td>৳7,000</td><td>A→1,000, B→2,000, C→3,000</td><td>All PAID + ৳1,000 customer credit</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <h3>4. Overpayment, advances &amp; credit balances</h3>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Scenario</th><th>Numbers</th><th>Result</th></tr></thead>
+                        <tbody>
+                            <tr><td>Overpayment</td><td>Invoice 1,000 / Payment 1,200</td><td>PAID + ৳200 credit balance</td></tr>
+                            <tr><td>Large overpayment</td><td>Invoice 1,000 / Payment 2,000</td><td>PAID + ৳1,000 credit balance</td></tr>
+                            <tr><td>Advance before invoice</td><td>Advance 1,000, later Invoice 1,500</td><td>Advance applied → Outstanding 500</td></tr>
+                            <tr><td>Advance larger than invoice</td><td>Advance 2,000, Invoice 1,000</td><td>PAID + ৳1,000 remains as credit</td></tr>
+                            <tr><td>New payment spills into credit</td><td>Balance 200 due, Payment 500</td><td>200 → invoice (PAID), 300 → credit</td></tr>
+                            <tr><td>Opening balance</td><td>Migrated AR opening = 1,000</td><td>Posted as an AR opening entry, not a new invoice</td></tr>
+                            <tr><td>Existing credit offsets new invoice</td><td>Credit 500, new Invoice 1,000</td><td>Customer owes only ৳500</td></tr>
+                            <tr><td>Refund of credit balance</td><td>Credit 500, refund 300</td><td>Remaining credit = ৳200</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <h3>5. Credit notes, discounts, write-offs &amp; tax</h3>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Scenario</th><th>Numbers</th><th>Result</th></tr></thead>
+                        <tbody>
+                            <tr><td>Partial credit note</td><td>Invoice 1,000, Credit Note 100, Payment 500</td><td>Outstanding = 400</td></tr>
+                            <tr><td>Full credit note</td><td>Invoice 1,000, Credit Note 1,000</td><td>Net invoice = 0 → SETTLED, no payment needed</td></tr>
+                            <tr><td>Settlement discount</td><td>Invoice 1,000, Discount 50, Payment 950</td><td>Outstanding = 0 (DR Sales Discount 50)</td></tr>
+                            <tr><td>Small write-off</td><td>Invoice 1,000, Payment 995</td><td>৳5 written off → PAID + WRITTEN_OFF</td></tr>
+                            <tr><td>Large write-off (needs approval)</td><td>Invoice 1,000, Payment 700</td><td>৳300 written off on management approval</td></tr>
+                            <tr><td>Payment + credit + write-off combined</td><td>Payment 850 + Credit 100 + Write-off 50</td><td>1,000 total → Outstanding = 0</td></tr>
+                            <tr><td>VAT-inclusive posting</td><td>Total 1,000 = Net 909.09 + VAT 90.91</td><td>DR AR 1,000 / CR Sales 909.09 / CR VAT 90.91</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <h3>6. Reversals, cancellations &amp; corrections</h3>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Scenario</th><th>Correct handling</th></tr></thead>
+                        <tbody>
+                            <tr><td>Draft invoice cancelled</td><td>No GL impact — it was never posted, safe to delete/cancel outright</td></tr>
+                            <tr><td>Posted, paid invoice needs cancelling</td><td>Never delete — issue a Credit Note, then a Refund if cash already moved</td></tr>
+                            <tr><td>Payment reversed (bounced cheque / bank reject)</td><td>Reversal JE: DR AR / CR Bank — invoice returns to OUTSTANDING</td></tr>
+                            <tr><td>Posted payment cancelled by mistake</td><td>Reverse it (create an offsetting JE) — never hard-delete a posted payment</td></tr>
+                            <tr><td>Duplicate payment received</td><td>Second payment stays unallocated, then refunded or applied to a future invoice</td></tr>
+                            <tr><td>Payment allocated to the wrong invoice</td><td>Reverse the allocation, create a new one on the correct invoice — both logged in the audit trail</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <h3>7. Timing, currency &amp; operational scenarios</h3>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>Scenario</th><th>Correct handling</th></tr></thead>
+                        <tbody>
+                            <tr><td>Gateway payment pending/failed</td><td>Invoice stays OUTSTANDING until the gateway confirms — never mark PAID on "pending"</td></tr>
+                            <tr><td>Gateway clearing &amp; fee</td><td>Route through a Clearing Account, then split Bank + Fee on settlement (see <a href="#chart-of-accounts">Chart of Accounts</a>)</td></tr>
+                            <tr><td>Multi-currency invoice</td><td>Store invoice &amp; payment at their own exchange rates; the difference posts as FX Gain/Loss</td></tr>
+                            <tr><td>Cash shortage/overage at till</td><td>Post the difference to an approved Cash Over/Short account — never silently adjust the customer payment</td></tr>
+                            <tr><td>Paid early vs. paid late</td><td>Track <code>days_early</code> / <code>days_late</code> separately for DSO, aging, and collection reports</td></tr>
+                            <tr><td>Allocation ordering</td><td>Configurable rule: oldest-invoice-first (FIFO), due-date order, or manual user selection</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <h3>8. Every scenario mirrors onto Accounts Payable</h3>
+                    <p>Nothing above is customer-specific — replace Customer→Supplier, Invoice→Vendor Bill, and Accounts Receivable→Accounts Payable, and the exact same allocation, reconciliation, and status logic applies.</p>
+                    <div class="table-wrap">
+                    <table>
+                        <thead><tr><th>AR scenario</th><th>AP mirror</th></tr></thead>
+                        <tbody>
+                            <tr><td>Invoice 1,000, Payment 0</td><td>Bill 1,000, Payment 0 → AP = 1,000</td></tr>
+                            <tr><td>Invoice 1,000, Payment 500</td><td>Bill 1,000, Payment 500 → AP = 500</td></tr>
+                            <tr><td>Invoice 1,000, Payment 1,000</td><td>Bill 1,000, Payment 1,000 → AP = 0, PAID</td></tr>
+                            <tr><td>Overpayment → customer credit</td><td>Overpayment → supplier advance/credit</td></tr>
+                            <tr><td>One payment across A/B/C invoices</td><td>One payment across A/B/C vendor bills</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+
+                    <div class="success-box">
+                        <strong>✅ The takeaway:</strong> none of these 40+ conditions need a special case in application code. They all fall out automatically once <code>Outstanding</code> is a derived value, allocations are many-to-many, and every adjustment (credit, write-off, discount, FX difference) is its own typed transaction rather than a hand-edit to <code>paid_amount</code>.
+                    </div>
+                </section>
+
+                <section id="three-way-matching">
+                    <h2>🔍 Three-Way Matching</h2>
+                    <p>On the purchase side, mature ERPs cross-check the Purchase Order, Goods Receipt, and Vendor Bill before releasing payment:</p>
+                    <pre><code>Purchase Order    100 units @ ৳1,000
+Goods Receipt      95 units received
+Vendor Bill       100 units billed
+                    ─────────────────
+                    Mismatch = 5 units  →  flagged for approval</code></pre>
+                    <p>The sales-side equivalent compares Ordered vs. Delivered vs. Invoiced quantities before an invoice is allowed to post.</p>
+                </section>
+
+                <section id="audit-trail">
+                    <h2>🛡️ Audit Trail: Why You Never Delete Posted Documents</h2>
+                    <p>A posted invoice is referenced by AR, the General Ledger, tax reports, and customer statements. Deleting it silently breaks all of them. Enterprise systems only allow <code>Draft → Edit</code>, but <code>Posted → Reverse / Cancel / Credit Note</code> — never <code>Posted → Delete</code>.</p>
+                    <pre><code>audit_log
+--------------------
+id
+user_id
+action          -- CREATE, UPDATE, POST, CANCEL
+entity_type     -- "invoice", "payment", ...
+entity_id
+timestamp
+old_values      (jsonb)
+new_values      (jsonb)
+reason</code></pre>
+                    <p>Corrections to posted financial data should be made by <strong>reversing</strong> the original entry and posting a new one — never by rewriting history:</p>
+                    <pre><code>Original JE:  DR Expense 50,000 / CR Bank 50,000
+Reversal JE:  DR Bank 50,000 / CR Expense 50,000
+Corrected JE: (the accurate entry)</code></pre>
+                    <div class="warning-box">
+                        <strong>⚠️ Fiscal period locking:</strong> Once a period (e.g. August 2026) is closed, no user should be able to post or edit entries dated within it without an explicit, authorized adjustment entry.
+                    </div>
+                </section>
+
+                <section id="schema">
+                    <h2>🗄️ Recommended Database Schema (Django/PostgreSQL)</h2>
+                    <p>For a Django/PostgreSQL ERP, keep Sales, Purchase, and Accounting as separate layers connected through documents and journal entries — not as tightly-coupled tables reaching into each other's internals.</p>
+                    <pre><code>Customer ──┬── Sales Order ── Order Lines
+           │
+           └── Invoice ── Invoice Lines
+                  │
+                  ↓
+          Accounts Receivable
+                  │
+                  ↓
+          Payment Allocation ←── Payment
+                  │
+                  ↓
+            Journal Entry ── Journal Entry Lines
+                  │
+                  ↓
+              GL Accounts
+
+Supplier ──┬── Purchase Order ── PO Lines
+           │
+           └── Vendor Bill ── Bill Lines
+                  │
+                  ↓
+           Accounts Payable
+                  │
+                  ↓
+          Payment Allocation ←── Supplier Payment
+                  │
+                  ↓
+            Journal Entry ── Journal Entry Lines
+                  │
+                  ↓
+              GL Accounts</code></pre>
+                    <p>Core entities worth modeling explicitly:</p>
+                    <pre><code>Customer, Supplier
+ChartOfAccount, Account
+
+SalesOrder, SalesOrderLine
+Delivery, DeliveryLine
+Invoice, InvoiceLine
+
+PurchaseOrder, PurchaseOrderLine
+GoodsReceipt, GoodsReceiptLine
+VendorBill, VendorBillLine
+
+Payment, PaymentAllocation
+CreditNote, CreditNoteLine, DebitNote
+
+JournalEntry, JournalEntryLine
+Reconciliation, ReconciliationLine
+
+CashAccount, BankAccount
+Tax, TaxRate, Currency, ExchangeRate
+AuditLog, DocumentSequence</code></pre>
+                    <div class="info-box">
+                        <strong>💡 Document numbering:</strong> Never expose raw primary keys to users. Generate business references such as <code>INV-2026-000123</code>, <code>PAY-2026-000045</code>, <code>PO-2026-000012</code> via a <code>DocumentSequence</code> table, and keep <code>id</code> internal.
+                    </div>
+                </section>
+
+                <section id="chart-of-accounts">
+                    <h2>📊 Chart of Accounts &amp; Control Accounts</h2>
+                    <p>Double-entry accounting needs a structured Chart of Accounts underneath it:</p>
+                    <pre><code>1000 Assets
+├── 1100 Cash
+├── 1200 Bank
+├── 1300 Accounts Receivable   (control account)
+└── 1400 Inventory
+
+2000 Liabilities
+├── 2100 Accounts Payable      (control account)
+└── 2200 VAT Payable
+
+3000 Equity
+└── 3100 Owner Capital
+
+4000 Revenue
+├── 4100 Product Sales
+└── 4200 Service Revenue
+
+5000 Expenses
+├── 5100 Salary
+├── 5200 Rent
+└── 5300 Utilities</code></pre>
+                    <p>For payment methods like bKash, Nagad, or card gateways, model them as real financial accounts rather than free-text strings — and route gateway payments through a <strong>clearing account</strong> so gateway fees reconcile cleanly:</p>
+                    <pre><code>Customer pays ৳10,000 by card:
+  DR Card Clearing Account    10,000
+      CR Accounts Receivable          10,000
+
+Bank settles, minus a ৳200 gateway fee:
+  DR Bank                      9,800
+  DR Payment Gateway Fee         200
+      CR Card Clearing Account         10,000
+
+Card Clearing Account balance = 0</code></pre>
+                </section>
+
+                <section id="best-practices">
+                    <h2>✅ Best Practices Checklist</h2>
+                    <div class="success-box">
+                        <h3 style="margin-top:0;">Five concepts to master first</h3>
+                        <ul>
+                            <li><strong>Document lifecycle</strong> — Order → Delivery → Invoice → Payment, each a distinct, independently-auditable step.</li>
+                            <li><strong>Double-entry accounting</strong> — every financial event balances debits and credits.</li>
+                            <li><strong>AR / AP</strong> — who owes whom, tracked as subledgers reconciled against GL control accounts.</li>
+                            <li><strong>Allocation &amp; reconciliation</strong> — a many-to-many link between payments and invoices, never a single foreign key.</li>
+                            <li><strong>Audit trail</strong> — posted financial documents are reversed or credited, never silently edited or deleted.</li>
+                        </ul>
+                    </div>
+                    <p>Once these five are correct, Sales, Purchase, POS, Inventory, Tax, and Expense modules can all be built on top of the same financial foundation, with the <strong>accounting engine as the central authority</strong> rather than `invoice`, `payment`, `sales`, and `purchase` tables reaching directly into each other.</p>
+
+                    <h3>Final words</h3>
+                    <p>The most important architectural rule: don't make the <code>invoice</code> table responsible for everything. Business modules generate financial events; a dedicated accounting engine records and reconciles those events. That separation is what makes an ERP scale, audit cleanly, and survive years of feature growth without turning into a tangle of ad-hoc status flags.</p>
+
+                    <div class="mt-8 pt-6 border-t border-gray-200">
+                        <a href="blog.html" class="inline-flex items-center text-blue-600 hover:text-blue-800 font-semibold">
+                            ← Back to Blog
+                        </a>
+                    </div>
+                </section>
+            </article>
+        </div>
+    </main>
+
+    <!-- Back to Top Button -->
+    <div class="back-to-top" id="backToTop">
+        ↑
+    </div>
+
+    <!-- Footer -->
+<footer class="footer" style="margin-top: 60px;">
+<div class="container">
+  <div class="footer-inner">
+    <div class="footer-brand">
+      <strong>Md. Mostasim Mahmud Tasim</strong>
+      <p>Software Engineer</p>
+    </div>
+    <div class="footer-links">
+      <a href="https://github.com/tasim313" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/md-mostasim-mahmud-tasim" target="_blank">LinkedIn</a>
+      <a href="mailto:tasim.swe@gmail.com">Email</a>
+    </div>
+  </div>
+  <p class="footer-copy">&copy; 2026 Md. Mostasim Mahmud Tasim. All rights reserved.</p>
+</div>
+</footer>
+<script src="js/main.js"></script>
+<script>
+    document.querySelectorAll('pre').forEach(pre => {
+        pre.addEventListener('click', function() {
+            const code = this.textContent;
+            navigator.clipboard.writeText(code).then(() => {
+                const originalBg = this.style.backgroundColor;
+                this.style.backgroundColor = '#059669';
+                setTimeout(() => { this.style.backgroundColor = originalBg; }, 500);
+            });
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds two new blog articles with matching site design: a deep dive into invoice vs payment ERP accounting (relationship diagrams, lifecycle flowcharts, and a scenario playbook), and a 15-level accounting-to-ERP curriculum blueprint with a subject-matter knowledge tree and a six-perspective article framework. Both are linked from blog.html.